### PR TITLE
HEE-199: Sitemap and page configuration approach/setup for push notification service-worker.js rendering

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
@@ -30,6 +30,9 @@ definitions:
               hst:componentconfigurationid: hst:pages/searchresults
               hst:pagetitle: Search
               hst:relativecontentpath: listing-pages/search-results
+          /service-worker.js:
+            jcr:primaryType: hst:sitemapitem
+            hst:componentconfigurationid: hst:pages/service-worker
         /hst:abstractpages:
           jcr:primaryType: hst:pages
         /hst:pages:
@@ -104,6 +107,9 @@ definitions:
           /searchbanklisting-main:
             jcr:primaryType: hst:template
             hst:renderpath: webfile:/freemarker/hee/catalog/searchbanklisting-main.ftl
+          /service-worker:
+            jcr:primaryType: hst:template
+            hst:renderpath: webfile:/freemarker/hee/push-notification/service-worker.ftl
         /hst:sitemenus:
           jcr:primaryType: hst:sitemenus
         /hst:sitemapitemhandlers:

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/service-worker.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/service-worker.yaml
@@ -1,0 +1,8 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/common/hst:pages/service-worker:
+      jcr:primaryType: hst:component
+      hst:componentclassname: uk.nhs.hee.web.components.ServiceWorkerComponent
+      hst:parameternames: [lks-pn-subdomain-channel-part]
+      hst:parametervalues: [library]
+      hst:template: service-worker

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/push-notification/service-worker.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/push-notification/service-worker.ftl
@@ -1,0 +1,6 @@
+<#ftl output_format="JavaScript">
+<#if channelPNSubDomainChannelPart?has_content>
+  <#compress>
+    ${'importScripts("https://${channelPNSubDomainChannelPart}-push.pushengage.com/service-worker.js?ver=2.3.0");'}
+  </#compress>
+</#if>

--- a/site/components/src/main/java/uk/nhs/hee/web/components/ServiceWorkerComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/ServiceWorkerComponent.java
@@ -1,0 +1,23 @@
+package uk.nhs.hee.web.components;
+
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.onehippo.cms7.essentials.components.CommonComponent;
+
+public class ServiceWorkerComponent extends CommonComponent {
+
+    private static final String CHANNEL_PUSH_NOTIFICATION_SUBDOMAIN_CHANNEL_PART_PARAM_SUFFIX =
+            "-pn-subdomain-channel-part";
+
+    @Override
+    public void doBeforeRender(final HstRequest request, final HstResponse response) {
+        super.doBeforeRender(request, response);
+
+        final String channelId = request.getRequestContext().getResolvedMount().getMount()
+                .getHstSite().getChannel().getId();
+        final String channelPNSubDomainChannelPart = getComponentLocalParameter(
+                channelId + CHANNEL_PUSH_NOTIFICATION_SUBDOMAIN_CHANNEL_PART_PARAM_SUFFIX);
+
+        request.setModel("channelPNSubDomainChannelPart", channelPNSubDomainChannelPart);
+    }
+}


### PR DESCRIPTION
@Raq-HEE  - As discussed, here is setup to serve push notification `service-worker.js` using sitemap & page configuration. The setup is currently configured with `lks` channel push notification domain (`library-push.pushengage.com`) and push notification domains for other channels could be configured on `/hst:hst/hst:configurations/common/hst:pages/service-worker` node via `@hst:parameternames/hst:parametervalues ` properties. Could you review ? Thanks!