### PR TITLE
NWPS-949 Add backend processing for table component

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-table-document.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-table-document.yaml
@@ -1,0 +1,10 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:queries/hippo:templates/new-table-document:
+      jcr:primaryType: hippostd:templatequery
+      hippostd:modify: [./_name, $name, './hippotranslation:locale', $inherited, './hippotranslation:id',
+        $uuid, './hippostdpubwf:createdBy', $holder, './hippostdpubwf:creationDate',
+        $now, './hippostdpubwf:lastModifiedBy', $holder, './hippostdpubwf:lastModificationDate',
+        $now, './hippostd:holder', $holder]
+      jcr:language: xpath
+      jcr:statement: //element(*,hipposysedit:namespacefolder)/element(*,mix:referenceable)/element(*,hipposysedit:templatetype)/hipposysedit:prototypes/element(hipposysedit:prototype,hee:table)

--- a/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-table-folder.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-table-folder.yaml
@@ -1,0 +1,16 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:queries/hippo:templates/new-table-folder:
+      jcr:primaryType: hippostd:templatequery
+      hippostd:modify: [./_name, $name, './hippotranslation:id', $uuid, './hippotranslation:locale',
+        $inherited]
+      jcr:language: xpath
+      jcr:statement: /jcr:root/hippo:configuration/hippo:queries/hippo:templates/new-tables-folder/hippostd:templates/node()
+      /hippostd:templates:
+        jcr:primaryType: hippostd:templates
+        /hippostd:folder:
+          jcr:primaryType: hippostd:folder
+          jcr:mixinTypes: ['hippotranslation:translated']
+          hippostd:foldertype: [new-table-document, new-table-folder]
+          hippotranslation:id: generated id
+          hippotranslation:locale: inherited locale

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
@@ -352,3 +352,13 @@ definitions:
       /en:
         jcr:primaryType: hipposys:resourcebundle
         jcr:name: Warning callout
+    /hippo:configuration/hippo:translations/hippo:types/hee:table:
+      jcr:primaryType: hipposys:resourcebundles
+      /en:
+        jcr:primaryType: hipposys:resourcebundle
+        jcr:name: Table
+    /hippo:configuration/hippo:translations/hippo:types/hee:tableReference:
+      jcr:primaryType: hipposys:resourcebundles
+      /en:
+        jcr:primaryType: hipposys:resourcebundle
+        jcr:name: Table (reusable)

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
@@ -101,12 +101,6 @@
 [hee:detailsReference] > hippo:compound, hippostd:relaxed
   orderable
 
-[hee:newsletterSubscribeForm] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
-  orderable
-
-[hee:newsletterSubscribeFormReference] > hippo:compound, hippostd:relaxed
-  orderable
-
 [hee:event] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
   orderable
 
@@ -190,6 +184,12 @@
 [hee:news] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
   orderable
 
+[hee:newsletterSubscribeForm] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
+  orderable
+
+[hee:newsletterSubscribeFormReference] > hippo:compound, hippostd:relaxed
+  orderable
+
 [hee:pageLastNextReview] > hippo:compound, hippostd:relaxed
   orderable
 
@@ -209,6 +209,12 @@
   orderable
 
 [hee:statementCardReference] > hippo:compound, hippostd:relaxed
+  orderable
+
+[hee:table] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
+  orderable
+
+[hee:tableReference] > hippo:compound, hippostd:relaxed
   orderable
 
 [hee:tabPanel] > hippo:compound, hippostd:relaxed

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/table.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/table.yaml
@@ -1,0 +1,80 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/table:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: e8dc12b7-a806-433a-ab47-cdb88af1f3b7
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 495cb865-880f-491e-b6b7-70305b63724c
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
+          jcr:uuid: c1dcb22c-c8aa-4700-9ce9-af04c4236a7a
+          hipposysedit:node: true
+          hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
+          hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
+          /caption:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:caption
+            hipposysedit:primary: false
+            hipposysedit:type: String
+          /content:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:content
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:html
+            hipposysedit:validators: [required]
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:table
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          jcr:mixinTypes: ['mix:referenceable']
+          hee:caption: ''
+          jcr:uuid: f035060b-f1db-47a7-ae39-264c798acc56
+          hippostdpubwf:lastModificationDate: 2022-05-17T11:44:49.093+01:00
+          hippostdpubwf:creationDate: 2022-05-17T11:44:49.093+01:00
+          /hee:content:
+            jcr:primaryType: hippostd:html
+            hippostd:content: ''
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
+          frontend:services: [wicket.id, validator.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /caption:
+            jcr:primaryType: frontend:plugin
+            caption: Caption
+            field: caption
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+          /content:
+            jcr:primaryType: frontend:plugin
+            caption: Table content
+            field: content
+            hint: ''
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/tableReference.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/tableReference.yaml
@@ -1,0 +1,54 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/tableReference:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: ee057ace-30f2-4aad-862f-a24bf0f9375c
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 2e42feac-18de-4d78-8010-bcf4764077d3
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
+          jcr:uuid: c5e33dcd-9c0e-45dd-8415-e7eb3f78fbd0
+          hipposysedit:node: true
+          hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
+          hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
+          /tabledataContentBlock:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:tabledataContentBlock
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:mirror
+            hipposysedit:validators: [required]
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:tableReference
+          /hee:tabledataContentBlock:
+            jcr:primaryType: hippo:mirror
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
+          frontend:services: [wicket.id, validator.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /tabledataContentBlock:
+            jcr:primaryType: frontend:plugin
+            caption: Table
+            field: tabledataContentBlock
+            hint: ''
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              nodetypes: ['hee:table']

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/components.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/components.ftl
@@ -15,6 +15,7 @@
 <#include "block-links.ftl">
 <#include "anchor-links.ftl">
 <#include "media.ftl">
+<#include "table.ftl">
 <#include "tabs.ftl">
 <#include "inset.ftl">
 <#include "button.ftl">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/table.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/table.ftl
@@ -1,0 +1,31 @@
+<#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"]>
+
+<#macro table table>
+    <#assign tableData = tableComponentService.getTableCellsFromTableMarkup(table.tabledataContentBlock.content.content)>
+    <table role="table" class="nhsuk-table-responsive">
+        <caption class="nhsuk-table__caption">${table.tabledataContentBlock.caption}</caption>
+        <#if tableData.headerCount gt 0>
+            <thead role="rowgroup" class="nhsuk-table__head">
+                <tr role="row">
+                    <#list tableData.headers as header>
+                        <th scope="col" role="columnheader">${header}</th>
+                    </#list>
+                </tr>
+            </thead>
+        </#if>
+        <#if tableData.rowCount gt 0>
+            <tbody class="nhsuk-table__body">
+                <#list tableData.rows as row>
+                    <tr role="row" class="nhsuk-table__row">
+                    <#list row as cell>
+                        <td role="cell" class="nhsuk-table__cell">
+                            <span class="nhsuk-table-responsive__heading">${tableData.getHeaderAt(cell?index)}</span>
+                            ${cell}
+                        </td>
+                    </#list>
+                    </tr>
+                </#list>
+            </tbody>
+        </#if>
+    </table>
+</#macro>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/Table.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/Table.java
@@ -1,0 +1,19 @@
+package uk.nhs.hee.web.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+@HippoEssentialsGenerated(internalName = "hee:table")
+@Node(jcrType = "hee:table")
+public class Table extends BaseDocument {
+    @HippoEssentialsGenerated(internalName = "hee:caption")
+    public String getCaption() {
+        return getSingleProperty("hee:caption");
+    }
+
+    @HippoEssentialsGenerated(internalName = "hee:content")
+    public HippoHtml getContent() {
+        return getHippoHtml("hee:content");
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/TableReference.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/TableReference.java
@@ -1,0 +1,15 @@
+package uk.nhs.hee.web.beans;
+
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+
+@HippoEssentialsGenerated(internalName = "hee:tableReference")
+@Node(jcrType = "hee:tableReference")
+public class TableReference extends HippoCompound {
+    @HippoEssentialsGenerated(internalName = "hee:tabledataContentBlock")
+    public HippoBean getTabledataContentBlock() {
+        return getLinkedBean("hee:tabledataContentBlock", HippoBean.class);
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/services/TableComponentService.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/services/TableComponentService.java
@@ -1,0 +1,27 @@
+package uk.nhs.hee.web.services;
+
+import org.jsoup.nodes.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.hee.web.utils.HeeTable;
+import uk.nhs.hee.web.utils.TableUtils;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+/**
+ * Provide services for the parsing and management of content in a table component
+ */
+public class TableComponentService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableComponentService.class);
+
+    public HeeTable getTableCellsFromTableMarkup(String textContent) {
+        Optional<Element> firstTable = TableUtils.findFirstTable(textContent);
+
+        if (firstTable.isPresent()) {
+            HeeTable x = TableUtils.findHeadersRowsAndCols(firstTable);
+            return x;
+        }
+        return new HeeTable(new ArrayList<>());
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/HeeTable.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/HeeTable.java
@@ -1,0 +1,78 @@
+package uk.nhs.hee.web.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Data storage object used for table information that will be output in the HEE web front end.
+ * The table contents are pre-parsed and is just stored in here
+ *
+ * There are a number of convenience methods in here that simplify the interaction with
+ * Freemarker such as getHeaderCount() and getHeaderAt()
+ *
+ */
+public class HeeTable {
+    private List<List<String>> rows;
+    private List<String> headers;
+
+    public HeeTable(List<List<String>> rows){
+        this.rows = rows;
+    }
+
+    public HeeTable(List<String> headers, List<List<String>> rows) {
+        this.headers = headers;
+        this.rows = rows;
+    }
+
+    public List<List<String>> getRows () {
+        return rows;
+    }
+
+    /**
+     * Convenience method for FTL
+     * @return the number of rows, or zero if none found
+     */
+    public int getRowCount() {
+        return rows == null ? 0 : rows.size();
+    }
+
+    /**
+     * Simplify access to the list of columns in a row
+     * @param rowNumber which is checked to be valid
+     * @return a list of cell contents for the nominated row
+     */
+    public List<String> getCellsForRow(int rowNumber) {
+        if (rows != null && rows.size() > rowNumber) {
+            return rows.get(rowNumber);
+        }
+
+        return new ArrayList<>();
+    }
+
+    public List<String> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Convenience method
+     * @return the number of header elements
+     */
+    public int getHeaderCount() {
+        return headers == null ? 0 : headers.size();
+    }
+
+    /**
+     * Return a specific header element, based on index
+     * @param index is the cell number we want
+     * @return the value for that cell, if available
+     */
+    public String getHeaderAt(int index) {
+        if (headers != null) {
+            if (headers.size() > index) {
+                return headers.get(index);
+            }
+        }
+
+        return "";
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/TableUtils.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/TableUtils.java
@@ -1,0 +1,129 @@
+package uk.nhs.hee.web.utils;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Utility methods to locate and then manipulate the content of a rich text field that will
+ * contain the definition of a table
+ */
+public class TableUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableUtils.class);
+
+    /**
+     * Look for a table element in a pre-supplied DOM. We assume it's syntactically correct but
+     * if we have any issues we return an empty Node.
+     * @param textContent is that content we want to parse
+     * @return will be a {@link Node}, with a name of 'table' that we can reference later
+     */
+    public static Optional<Element> findFirstTable(String textContent) {
+        Document parsed = Jsoup.parse(textContent);
+        Elements tableNodes = parsed.getElementsByTag("table");
+
+        if (tableNodes != null && tableNodes.size() > 0) {
+            Element e = tableNodes.get(0);
+            return Optional.of(e);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Find the rows and columns in a table and store them as cells
+     * @param tableContent is an Optional<Node> that contains the table element from a XHTML document
+     * @return A {@link List} of rows, each element of which contains the columns for that row
+     */
+    public static HeeTable findHeadersRowsAndCols(Optional<Element> tableContent) {
+        List<List<String>> rowsAndCols = new ArrayList<>();
+        List<String> headers = new ArrayList<>();
+
+        if (tableContent.isPresent() && "table".equals(tableContent.get().tagName())) {
+            // First child may be thead or straight into tbody
+            Elements tXXXElements = tableContent.get().children();
+            Element tbodyElement = null;
+
+            // Check for thead followed by tbody or just tbody
+            switch (tXXXElements.size()) {
+                case 2:
+                    Element theadElement = tXXXElements.get(0);
+                    if ("thead".equals(theadElement.tagName())) {
+                        headers = getHeaders(theadElement);
+                        if (tXXXElements.size() > 1 && "tbody".equals(tXXXElements.get(1).tagName())) {
+                            tbodyElement = tXXXElements.get(1);
+                        }
+                    }
+                    break;
+
+                case 1:
+                    if ("tbody".equals(tXXXElements.get(0).tagName())) {
+                        tbodyElement = tXXXElements.get(0);
+                    }
+                    break;
+
+                default:
+                    return new HeeTable(headers, rowsAndCols);
+            }
+
+            // tbodyElement will be set to tbody (or empty) now
+            if (tbodyElement != null && tbodyElement.children().size() > 0) {
+                Elements rows = tbodyElement.children();
+
+                if (rows.size() > 0 && "tr".equals(rows.get(0).tagName())) {
+                    for (int rowCounter = 0; rowCounter < rows.size(); rowCounter++) {
+                        Element row = rows.get(rowCounter);
+
+                        Elements cols = row.children();
+
+                        List<String> colList = null;
+
+                        for (int colCounter = 0; colCounter < cols.size(); colCounter++) {
+                            Element col = cols.get(colCounter);
+                            String value = col.text();
+
+                            if (colList == null) {
+                                colList = new ArrayList<>();
+                            }
+                            colList.add(value);
+                        }
+
+                        if (colList != null) {
+                            rowsAndCols.add(colList);
+                        }
+                    }
+                }
+            }
+        }
+        return new HeeTable(headers, rowsAndCols);
+    }
+
+    /**
+     * Locate nd process headers in a table
+     * @param theadElement
+     * @return
+     */
+    private static List<String> getHeaders(Element theadElement) {
+        Elements headers = theadElement.children();
+        List<String> headerText = new ArrayList<>();
+
+        if (headers.size() > 0) {
+            Elements headerCells = headers.get(0).children();
+
+            for (int thCounter = 0; thCounter < headerCells.size(); thCounter++) {
+                if ("th".equals(headerCells.get(thCounter).tagName())) {
+                    headerText.add(headerCells.get(thCounter).text());
+                }
+            }
+        }
+
+        return headerText;
+    }
+}

--- a/site/components/src/test/java/uk/nhs/hee/web/utils/TableUtilsTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/utils/TableUtilsTest.java
@@ -1,0 +1,178 @@
+package uk.nhs.hee.web.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+public class TableUtilsTest {
+    private static final String COMPLETE_ELEMENT_ONE = "<table>" +
+            "<tbody>" +
+            "<tr>" +
+            "<td attr=\"1\">T1.R1.C1</td>" +
+            "<td attr=\"2\">T1.R1.C2</td>" +
+            "</tr>" +
+            "<tr>" +
+            "<td attr=\"3\">T1.R2.C1</td>" +
+            "<td attr=\"4\">T1.R2.C2</td>" +
+            "</tr>" +
+            "</tbody>" +
+            "</table>";
+
+    private static final String COMPLETE_ELEMENT_THEAD = "<table>" +
+            "<thead>"+
+            "<tr>" +
+            "<th>Head 1</th" +
+            "<th>Head 2</th" +
+            "</tr>" +
+            "</thead>" +
+            "<tbody>" +
+            "<tr>" +
+            "<td attr=\"1\">T1.R1.C1</td>" +
+            "<td attr=\"2\">T1.R1.C2</td>" +
+            "</tr>" +
+            "<tr>" +
+            "<td attr=\"3\">T1.R2.C1</td>" +
+            "<td attr=\"4\">T1.R2.C2</td>" +
+            "</tr>" +
+            "</tbody>" +
+            "</table>";
+
+    private static final String INCOMPLETE_FIRST_ROW_ELEMENT_ONE = "<table>" +
+            "<tbody>" +
+            "<tr>" +
+            "</tr>" +
+            "<tr>" +
+            "<td attr=\"3\">T1.R2.C1</td>" +
+            "<td attr=\"4\">T1.R2.C2</td>" +
+            "</tr>" +
+            "</tbody>" +
+            "</table>";
+
+    private static final String EMPTY_ROWS = "<table>" +
+            "<tbody>" +
+            "<tr>" +
+            "</tr>" +
+            "<tr>" +
+            "</tr>" +
+            "</tbody>" +
+            "</table>";
+
+    private static final String COMPLETE_ELEMENT_TWO = "<table>" +
+            "<tbody>" +
+            "<tr>" +
+                "<td>T2.R1.C1</td>" +
+                "<td>T2.R1.C2</td>" +
+            "</tr>" +
+            "</tbody>" +
+            "</table>";
+    public static final String TABLE_SPAN_DATA_SPAN = "<table><span>data</span>";
+
+    @Test
+    public void testRejectNotSuppliedTableElement() {
+        assertEquals("Cannot find a complete table", Optional.empty(), TableUtils.findFirstTable("<span>data</span>"));
+    }
+
+    @Test
+    public void testAcceptIncompleteTableElement() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(TABLE_SPAN_DATA_SPAN);
+        assertEquals("Found a partial table", "<table></table>", convertNodeToStringForComparativePurposes(tableContent.get()));
+    }
+
+    @Test
+    public void testIsolateCompleteTableElement() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(COMPLETE_ELEMENT_ONE);
+        String content = convertNodeToStringForComparativePurposes(tableContent.get());
+        assertEquals("Looking for complete table element", COMPLETE_ELEMENT_ONE, content);
+    }
+
+    @Test
+    public void testIsolateFirstCompleteTableElement() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(COMPLETE_ELEMENT_ONE + COMPLETE_ELEMENT_TWO);
+        String content = convertNodeToStringForComparativePurposes(tableContent.get());
+        assertEquals("Looking for complete table element", COMPLETE_ELEMENT_ONE, content);
+    }
+
+    @Test
+    public void testRejectFirstCompleteTableElementWhenIncompleteAlsoInThere() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(COMPLETE_ELEMENT_ONE + "<table><span>data3></span>");
+        assertEquals("Looking for complete table element", COMPLETE_ELEMENT_ONE, convertNodeToStringForComparativePurposes(tableContent.get()));
+    }
+
+    @Test
+    public void testRejectEmptyTableNode() {
+        assertEquals("Expected to receive no rows when passing empty table element", 0, TableUtils.findHeadersRowsAndCols(Optional.empty()).getRows().size());
+    }
+
+    @Test
+    public void testRejectFirstNodeThatIsntATableNode() throws TransformerException, IOException, SAXException, ParserConfigurationException {
+        Optional<Element> emptyTableContent = createDocWithTopLevelNodeOfType("xyz");
+        assertEquals("Expected to receive no rows back when passing empty table element", 0, TableUtils.findHeadersRowsAndCols(emptyTableContent).getRows().size());
+    }
+
+    @Test
+    public void testRejectWhenFirstNodeIsTableNodeButNoRowsBeneath() throws TransformerException, IOException, SAXException, ParserConfigurationException {
+        Optional<Element> emptyTableContent = createDocWithTopLevelNodeOfType("table");
+        assertEquals("Expected to receive a row back when passing table element", 1, TableUtils.findHeadersRowsAndCols(emptyTableContent).getRows().size());
+    }
+
+    @Test
+    public void testFindTwoRowsWhenFirstNodeIsTableNodeAndHasRowsBeneath() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(COMPLETE_ELEMENT_ONE + COMPLETE_ELEMENT_TWO);
+        assertEquals("Expected to receive two rows of data", 2, TableUtils.findHeadersRowsAndCols(tableContent).getRows().size());
+    }
+
+    @Test
+    public void testFindTwoRowsWhenFirstNodeIsTableNodeAndHasRowsBeneathIncludingNBSP() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(COMPLETE_ELEMENT_ONE + COMPLETE_ELEMENT_TWO + "&nbsp;");
+        assertEquals("Expected to receive two rows of data", 2, TableUtils.findHeadersRowsAndCols(tableContent).getRows().size());
+    }
+
+    @Test
+    public void testFindNoRowsWhenFirstNodeIsTableNodeAndHasRowsWithNoColumnsBeneath() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(EMPTY_ROWS + COMPLETE_ELEMENT_TWO);
+        assertEquals("Expected to receive no rows of data", 0, TableUtils.findHeadersRowsAndCols(tableContent).getRows().size());
+    }
+
+    @Test
+    public void testFindOneRowWhenFirstNodeIsTableNodeAndHasRowsWithOnlyOneLotOfColumnsBeneath() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(INCOMPLETE_FIRST_ROW_ELEMENT_ONE + COMPLETE_ELEMENT_TWO);
+        HeeTable headersRowsAndCols = TableUtils.findHeadersRowsAndCols(tableContent);
+
+        assertEquals("Expected to receive one rows of data", 1, headersRowsAndCols.getRows().size());
+        assertEquals("Expected correct column content", "T1.R2.C1", headersRowsAndCols.getCellsForRow(0).get(0));
+    }
+
+    @Test
+    public void testFindTwoRowsWhenFirstNodeIsTHead() {
+        Optional<Element> tableContent = TableUtils.findFirstTable(COMPLETE_ELEMENT_THEAD);
+        assertEquals("Expected to receive two header cells", 2, TableUtils.findHeadersRowsAndCols(tableContent).getHeaders().size());
+        assertEquals("Expected to receive specific text in the first header cell", "Head 1", TableUtils.findHeadersRowsAndCols(tableContent).getHeaders().get(0));
+        assertEquals("Expected to receive specific text in the second header cell", "Head 2", TableUtils.findHeadersRowsAndCols(tableContent).getHeaders().get(1));
+        assertEquals("Expected to receive two rows of data", 2, TableUtils.findHeadersRowsAndCols(tableContent).getRows().size());
+    }
+
+    /*
+    Private methods follow
+     */
+    private Optional<Element> createDocWithTopLevelNodeOfType(String xyz) {
+        String workingContent = "<" + xyz + "><tbody><tr><td>hahahah</td></tr></tbody></" + xyz + ">";
+        Document data = Jsoup.parse(workingContent);
+        return Optional.of(data.getElementsByTag(xyz).get(0));
+    }
+
+    private String convertNodeToStringForComparativePurposes(Element node) {
+        String ret = node.toString();
+        String stripped = ret.replaceAll("\n[\\s]*", "");
+        return stripped;
+    }
+}


### PR DESCRIPTION
This is the first sub-task for ticket NWPS-911 (New: Table component). 
This code is responsible for managing the capture of data for a Table component using a new Document Type (Table). 

To manage the rendering of the content, we use a tableReference component, which allows the table to be added to any content block section for other document types.

Also included is a first draft of a table FTL file which may need to update when new CSS is available in a later sub-task.

