### PR TITLE
NWPS-874: External links card enhancement to not open links in a new window unless specified.

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/externalLink.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/externalLink.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: f508ae78-d4aa-4a24-a2f3-f3cb15d5b9fa
+          jcr:uuid: c6dbf8e4-caee-46d5-b5f4-59f3846625b2
           hipposysedit:node: true
           hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -33,12 +33,21 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: String
             hipposysedit:validators: [required]
+          /openLinkUrlNewWindow:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:openLinkUrlNewWindow
+            hipposysedit:primary: false
+            hipposysedit:type: Boolean
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
           jcr:primaryType: hee:externalLink
           hee:text: ''
           hee:url: ''
+          hee:openLinkUrlNewWindow: false
       /editor:templates:
         jcr:primaryType: editor:templateset
         /_default_:
@@ -65,5 +74,14 @@ definitions:
             hint: ''
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+          /openLinkUrlNewWindow:
+            jcr:primaryType: frontend:plugin
+            caption: Open link url in new window
+            field: openLinkUrlNewWindow
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+            hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig

--- a/repository-data/development/src/main/resources/hcm-actions.yaml
+++ b/repository-data/development/src/main/resources/hcm-actions.yaml
@@ -88,3 +88,5 @@ action-lists:
   - 1.0.40:
       /content/documents/lks/common: reload
       /content/documents/lks/guidance-pages: reload
+  - 1.0.41:
+      /content/documents/lks/common: reload

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
@@ -2117,7 +2117,7 @@
       jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
       jcr:uuid: 4b476239-b427-44b6-9b18-41af5ff3f3d8
       hippo:name: Resources
-      hippo:versionHistory: 3f1c998b-9424-400f-b3aa-5dc5e36d45a2
+      hippo:versionHistory: d00e700b-73a4-423d-bae0-873c50bb95d7
       /resources[1]:
         jcr:primaryType: hee:externalLinksCard
         jcr:mixinTypes: ['mix:referenceable']
@@ -2128,20 +2128,23 @@
         hippostd:state: draft
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-21T13:17:24.900+01:00
-        hippostdpubwf:lastModificationDate: 2021-05-21T13:17:24.900+01:00
+        hippostdpubwf:lastModificationDate: 2022-06-20T09:22:41.698+01:00
         hippostdpubwf:lastModifiedBy: admin
         hippotranslation:id: 29dfa580-f26e-4d12-806a-041193542655
         hippotranslation:locale: en
         /hee:externalLinks[1]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: London and KSS Support Portal
           hee:url: https://kss.hee.nhs.uk/
         /hee:externalLinks[2]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: 'General Medical Council (GMC): Statement on LTFT'
           hee:url: https://lonkssfoundation.hee.nhs.uk/gmc
         /hee:externalLinks[3]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: Gold Guide 8th Edition
           hee:url: https://www.copmed.org.uk/gold-guide-8th-edition/
       /resources[2]:
@@ -2154,20 +2157,23 @@
         hippostd:state: unpublished
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-21T13:17:24.900+01:00
-        hippostdpubwf:lastModificationDate: 2021-05-21T13:19:43.959+01:00
+        hippostdpubwf:lastModificationDate: 2022-06-20T09:22:44.364+01:00
         hippostdpubwf:lastModifiedBy: admin
         hippotranslation:id: 29dfa580-f26e-4d12-806a-041193542655
         hippotranslation:locale: en
         /hee:externalLinks[1]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: London and KSS Support Portal
           hee:url: https://kss.hee.nhs.uk/
         /hee:externalLinks[2]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: 'General Medical Council (GMC): Statement on LTFT'
           hee:url: https://lonkssfoundation.hee.nhs.uk/gmc
         /hee:externalLinks[3]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: Gold Guide 8th Edition
           hee:url: https://www.copmed.org.uk/gold-guide-8th-edition/
       /resources[3]:
@@ -2180,21 +2186,24 @@
         hippostd:state: published
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-21T13:17:24.900+01:00
-        hippostdpubwf:lastModificationDate: 2021-05-21T13:19:43.959+01:00
+        hippostdpubwf:lastModificationDate: 2022-06-20T09:22:44.364+01:00
         hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2021-05-21T13:19:56.615+01:00
+        hippostdpubwf:publicationDate: 2022-06-20T09:22:46.297+01:00
         hippotranslation:id: 29dfa580-f26e-4d12-806a-041193542655
         hippotranslation:locale: en
         /hee:externalLinks[1]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: London and KSS Support Portal
           hee:url: https://kss.hee.nhs.uk/
         /hee:externalLinks[2]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: 'General Medical Council (GMC): Statement on LTFT'
           hee:url: https://lonkssfoundation.hee.nhs.uk/gmc
         /hee:externalLinks[3]:
           jcr:primaryType: hee:externalLink
+          hee:openLinkUrlNewWindow: false
           hee:text: Gold Guide 8th Edition
           hee:url: https://www.copmed.org.uk/gold-guide-8th-edition/
   /file-links-cards:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/external-links-card.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/external-links-card.ftl
@@ -9,9 +9,14 @@
 
                 <ul class="nhsuk-related-links-card__list">
                     <#list card.externalLinks as link>
+                        <#assign openInNewWindow=false/>
+                        <#if link.openLinkUrlNewWindow?? && link.openLinkUrlNewWindow>
+                            <#assign openInNewWindow=true/>
+                        </#if>
+
                         <li>
-                            <a class="nhsuk-related-links-card__link" href="${link.url}" target="_blank">
-                                ${link.text} (opens in new window)
+                            <a class="nhsuk-related-links-card__link" href="${link.url}" ${openInNewWindow?then('target="_blank"', '')}>
+                                ${link.text}${openInNewWindow?then(' (opens in new window)', '')}
                             </a>
                         </li>
                     </#list>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/ExternalLink.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/ExternalLink.java
@@ -16,4 +16,9 @@ public class ExternalLink extends HippoCompound {
     public String getUrl() {
         return getSingleProperty("hee:url");
     }
+
+    @HippoEssentialsGenerated(internalName = "hee:openLinkUrlNewWindow")
+    public Boolean getOpenLinkUrlNewWindow() {
+        return getSingleProperty("hee:openLinkUrlNewWindow");
+    }
 }


### PR DESCRIPTION
- Added an optional `Open link url in new window` field onto `External links card` DocumentType to let content editors choose to open the link in a new window.
- Updated `repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/external-links-card.ftl` freemarker template to not open the links in a window unless `Open link url in new window` is checked. Also, it appends ` (opens in new window)` to the Link text when `Open link url in new window` checked.