### PR TITLE
NWPS-809: Implementation to resolve internal links for MiniHub Guidance pages for link based document and compound types

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/multi-org-logo.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/multi-org-logo.ftl
@@ -1,4 +1,5 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#include "../macros/internal-link.ftl">
 
 <#-- @ftlvariable name="document" type="[
                                             uk.nhs.hee.web.beans.BlogPost,
@@ -16,9 +17,7 @@
         <#list document.logoGroup.logos as logo>
             <#--  Builds link  -->
             <#if logo.linkDocument??>
-                <#assign href>
-                    <@hst.link hippobean=logo.linkDocument/>
-                </#assign>
+                <#assign href=getInternalLinkURL(logo.linkDocument)>
                 <#assign openInNewWindow=false/>
             <#else>
                 <#assign href="${logo.linkURL}">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/action-link.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/action-link.ftl
@@ -1,12 +1,11 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#include "internal-link.ftl">
 
 <#macro actionLink actionLink>
     <#if actionLink??>
         <#assign openInNewWindow=false/>
         <#if actionLink.link.document??>
-            <#assign link>
-                <@hst.link hippobean=actionLink.link.document/>
-            </#assign>
+            <#assign link=getInternalLinkURL(actionLink.link.document)>
         <#else>
             <#assign link = "${actionLink.link.url}">
             <#if actionLink.link.openLinkUrlNewWindow>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/block-links.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/block-links.ftl
@@ -1,3 +1,5 @@
+<#include "internal-link.ftl">
+
 <#macro blockLinks block>
     <#if block??>
         <#if block.blockLinksContentBlock.blockLinks?size gt 0>
@@ -14,7 +16,7 @@
                 <ul class="nhsuk-list-blocklinks${colClass}">
                     <#list block.blockLinksContentBlock.blockLinks as linkBlock>
                         <li>
-                            <a href="<@hst.link hippobean=linkBlock.blockLink/>">
+                            <a href="${getInternalLinkURL(linkBlock.blockLink)}">
                                 <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                     <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z">
                                     </path>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/button.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/button.ftl
@@ -1,4 +1,6 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#include "internal-link.ftl">
+
 <#function buttonTypeBySelection buttontype>
     <#switch buttontype>
         <#case 'primary'>
@@ -20,17 +22,13 @@
 <#macro button button>
     <#if button?? && button.buttonContentBlock??>
         <#if button.buttonContentBlock.document??>
-            <#assign link>
-                <@hst.link hippobean=button.buttonContentBlock.document/>
-            </#assign>
-            <#assign cssname>
-            	${buttonTypeBySelection(button.buttonContentBlock.buttontype)}
-            </#assign>
+            <#assign link=getInternalLinkURL(button.buttonContentBlock.document)>
+            <#assign cssname=buttonTypeBySelection(button.buttonContentBlock.buttontype)>
         </#if>
         <#if link?has_content>
-				<button class="${cssname}" type="submit"  onclick="location.href ='${link}'"> 
+				<button class="${cssname}" type="submit" onclick="location.href ='${link}'">
 					${button.buttonContentBlock.label}
-				</button>			
+				</button>
         </#if>
     </#if>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/cta-card.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/cta-card.ftl
@@ -1,12 +1,11 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#include "internal-link.ftl">
 
 <#macro ctaCard ctaCard>
     <#if ctaCard??>
         <#assign openInNewWindow=false/>
         <#if ctaCard.ctaCardContentBlock.ctaLink.document??>
-            <#assign link>
-                <@hst.link hippobean=ctaCard.ctaCardContentBlock.ctaLink.document/>
-            </#assign>
+            <#assign link=getInternalLinkURL(ctaCard.ctaCardContentBlock.ctaLink.document)>
         <#else>
             <#assign link = "${ctaCard.ctaCardContentBlock.ctaLink.url}">
             <#if ctaCard.ctaCardContentBlock.ctaLink.openLinkUrlNewWindow>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/internal-link.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/internal-link.ftl
@@ -1,0 +1,18 @@
+<#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#assign hstCustom=JspTaglibs["http://www.hippoecm.org/jsp/hst/custom"] >
+
+<#--  Function which returns internal link for the document/content bean  -->
+<#function getInternalLinkURL contentBean>
+    <@hst.link hippobean=contentBean var="linkURL"/>
+
+    <@hst.link siteMapItemRefId="pagenotfound" var="pageNotFoundURL"/>
+    <#if linkURL == pageNotFoundURL && 'hee:guidance' == contentBean.contentType>
+        <#--  Tries to generate Mini-Hub Guidance link (in case if any available)
+              in case if the document/content is Guidance type
+              i.e. if the documetn is of type 'hee:guidance'  -->
+        <@hstCustom.getMiniHubGuidanceLink hippobean=contentBean var="linkURL"/>
+    </#if>
+
+    <#return linkURL>
+</#function>
+

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/internal-links-card.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/internal-links-card.ftl
@@ -1,5 +1,6 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
 <#assign fmt=JspTaglibs ["http://java.sun.com/jsp/jstl/fmt"] >
+<#include "internal-link.ftl">
 
 <#macro internalLinksCard card>
     <#if card??>
@@ -10,7 +11,7 @@
                 <ul class="nhsuk-related-links-card__list">
                     <#list card.internalLinks as link>
                         <li>
-                            <a class="nhsuk-related-links-card__link" href="<@hst.link hippobean=link.document/>">
+                            <a class="nhsuk-related-links-card__link" href="${getInternalLinkURL(link.document)}">
                                 ${link.text}
                             </a>
                         </li>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/link.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/link.ftl
@@ -1,9 +1,10 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#include "internal-link.ftl">
 
 <#macro link link cssClassName>
     <#if link?? && (link.document?? || link.url?has_content)>
         <#if link.document??>
-            <a class="${cssClassName}" href="<@hst.link hippobean=link.document/>"><#nested></a>
+            <a class="${cssClassName}" href="${getInternalLinkURL(link.document)}"><#nested></a>
         <#else>
             <a class="${cssClassName}" href="${link.url}"${link.openLinkUrlNewWindow?then(' target="_blank"','')}><#nested></a>
         </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
@@ -1,5 +1,6 @@
 <#ftl output_format="HTML">
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#include "internal-link.ftl">
 
 <#macro bulletinListItem items categoriesMap>
     <#list items as item>
@@ -38,7 +39,7 @@
     <@hst.link var="pageNotFoundURL" siteMapItemRefId="pagenotfound"/>
 
     <#list items as item>
-        <@hst.link hippobean=item var="pageURL"/>
+        <#assign pageURL=getInternalLinkURL(item)>
 
         <#if pageURL != pageNotFoundURL>
             <li>
@@ -62,7 +63,7 @@
     <@hst.link var="pageNotFoundURL" siteMapItemRefId="pagenotfound"/>
 
     <#list items as item>
-        <@hst.link hippobean=item var="pageURL"/>
+        <#assign pageURL=getInternalLinkURL(item)>
 
         <#if pageURL != pageNotFoundURL>
             <li>
@@ -242,7 +243,7 @@
     <@hst.link var="pageNotFoundURL" siteMapItemRefId="pagenotfound"/>
 
     <#list items as item>
-        <@hst.link hippobean=item var="pageURL"/>
+        <#assign pageURL=getInternalLinkURL(item)>
 
         <#if ['Bulletin', 'CaseStudy', 'SearchBank', 'Event']?seq_contains(item.class.simpleName) || (pageURL != pageNotFoundURL || ('uk.nhs.hee.web.beans.Guidance' == item.getClass().getName() && miniHubGuidancePathToURLMap[item.path]??))>
             <li>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/nav-map.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/nav-map.ftl
@@ -1,4 +1,5 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#include "internal-link.ftl">
 
 <#macro navMap block navMapRegionMap>
     <h2>${block.title}</h2>
@@ -17,9 +18,7 @@
             <ul id="regionList">
                 <#list block.links as link>
                     <#if link.document??>
-                        <#assign linkHREF>
-                            <@hst.link hippobean=link.document/>
-                        </#assign>
+                        <#assign linkHREF=getInternalLinkURL(link.document)>
                         <#assign openInNewWindow=false/>
                     <#else>
                         <#assign linkHREF="${link.url}">

--- a/site/components/src/main/java/uk/nhs/hee/web/tag/GetMiniHubGuidanceLink.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/tag/GetMiniHubGuidanceLink.java
@@ -1,0 +1,103 @@
+package uk.nhs.hee.web.tag;
+
+import org.hippoecm.hst.configuration.hosting.Mount;
+import org.hippoecm.hst.core.linking.HstLink;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.hippoecm.hst.tag.HstLinkTag;
+import org.hippoecm.hst.util.HstRequestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.hee.web.utils.HstUtils;
+import uk.nhs.hee.web.utils.MiniHubGuidanceLinkUtils;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+
+import static org.hippoecm.hst.utils.TagUtils.writeOrSetVar;
+
+
+/**
+ * A custom HST link tag ({@code <hstCustom:getMiniHubGuidanceLink/>}) class [extended from the OOTB {@code <hst:link/>}
+ * tag class ({@link HstLinkTag})] which essentially generates URL(s) for Mini-Hub Guidance document(s).
+ * Note that the tag supports {@code hippobean} attribute only and so suggest to use OOTB core <hst:link/> tag
+ * to generate links based on other attributes.
+ *
+ * Also, note that the class has been extended from OOTB {@code <hst:link/>} tag class ({@link HstLinkTag})
+ * in order to reuse its attributes as well as to support other OOTB link attributes in the future if required.
+ */
+public class GetMiniHubGuidanceLink extends HstLinkTag {
+    // Write details re. why the class was extended from HstLinkTag and supported attributes.
+    private static final long serialVersionUID = 4235666776137782639L;
+    private static final Logger log = LoggerFactory.getLogger(GetMiniHubGuidanceLink.class);
+
+    /* (non-Javadoc)
+     * @see javax.servlet.jsp.tagext.TagSupport#doEndTag()
+     */
+    @Override
+    public int doEndTag() throws JspException {
+        if (skipTag) {
+            return EVAL_PAGE;
+        }
+
+        final HttpServletRequest servletRequest = (HttpServletRequest) pageContext.getRequest();
+        final HstRequestContext reqContext = HstRequestUtils.getHstRequestContext(servletRequest);
+        final Mount requestedMount = reqContext.getResolvedMount().getMount();
+        final String pageNotFoundURL = HstUtils.getPageNotFoundURL(reqContext, requestedMount, fullyQualified);
+
+        // Get [Guidance] content handle node
+        final Node contentHandleNode = getContentHandleNode(reqContext);
+        if (contentHandleNode == null) {
+            writeOrSetVar(pageNotFoundURL, var, pageContext, scope);
+            return EVAL_PAGE;
+        }
+
+        // Get mini-hub guidance link for 'identifiableContentBean' node instance (if any).
+        final HstLink miniHubGuidanceLink =
+                MiniHubGuidanceLinkUtils.getLink(contentHandleNode, canonical, reqContext, requestedMount);
+        if (miniHubGuidanceLink == null) {
+            writeOrSetVar(pageNotFoundURL, var, pageContext, scope);
+            return EVAL_PAGE;
+        }
+
+        // Escapes XML entities in the URL in case if instructed
+        String urlString = miniHubGuidanceLink.toUrlForm(reqContext, fullyQualified);
+        if (Boolean.TRUE.equals(escapeXml)) {
+            urlString = HstRequestUtils.escapeXml(urlString);
+        }
+
+        // Write/set mini-hub guidance link in the pageContext.
+        writeOrSetVar(urlString, var, pageContext, scope);
+        return EVAL_PAGE;
+    }
+
+    /**
+     * Returns {@code hippoBean} handle node i.e. the identifiable content handle node.
+     *
+     * @param reqContext the {@link HstRequestContext} instance.
+     * @return {@code hippoBean} handle node i.e. the identifiable content handle node.
+     */
+    private Node getContentHandleNode(final HstRequestContext reqContext) {
+        if (identifiableContentBean == null) {
+            return null;
+        }
+
+        try {
+            // Get 'identifiableContentBean' node instance.
+            final Node contentNode = reqContext.getSession().getNodeByIdentifier(identifiableContentBean.getIdentifier());
+            if (contentNode == null) {
+                return null;
+            }
+
+            // return 'identifiableContentBean' handle node instance.
+            return contentNode.getParent();
+        } catch (final RepositoryException e) {
+            log.error("Caught error '{}' while getting node for the content with identifier '{}'",
+                    e.getMessage(), identifiableContentBean.getIdentifier());
+        }
+
+        return null;
+    }
+
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/HstUtils.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/HstUtils.java
@@ -1,6 +1,7 @@
 package uk.nhs.hee.web.utils;
 
 import org.apache.commons.lang.StringUtils;
+import org.hippoecm.hst.configuration.hosting.Mount;
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
@@ -20,9 +21,29 @@ import java.util.List;
 
 import static org.hippoecm.hst.content.beans.query.builder.ConstraintBuilder.constraint;
 
+/**
+ * Class containing HST utility methods.
+ */
 public class HstUtils {
+    public static final String PAGE_NOT_FOUND_SITE_MAP_PATH = "pagenotfound";
     private static final Logger LOGGER = LoggerFactory.getLogger(HstUtils.class);
 
+    /**
+     * Private constructor to restrict instantiating this utility class.
+     */
+    private HstUtils() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Returns values of the given {@code parameter} as {@link List<String>}
+     * if available in the {@code request} instance. Otherwise, returns an empty list.
+     *
+     * @param request   the {@link HstRequestContext} instance.
+     * @param parameter the parameter whose values needs to be returned.
+     * @return values of the given {@code parameter} as {@link List<String>}
+     * if available in the {@code request} instance. Otherwise, returns an empty list.
+     */
     public static List<String> getQueryParameterValues(final HstRequest request, final String parameter) {
         final String[] parameterValues = request.getParameterValues(parameter);
         if (parameterValues == null) {
@@ -54,10 +75,94 @@ public class HstUtils {
     }
 
     /**
+     * Returns {@code pagenotfound} {@link HstLink} instance.
+     *
+     * @param requestContext the {@link HstRequestContext} instance.
+     * @param mount          the {@link Mount} instance.
+     * @return {@code pagenotfound} {@link HstLink} instance.
+     */
+    private static HstLink getPageNotFoundLink(
+            final HstRequestContext requestContext,
+            final Mount mount
+    ) {
+        return requestContext.getHstLinkCreator().create(PAGE_NOT_FOUND_SITE_MAP_PATH, mount);
+    }
+
+    /**
+     * Returns {@code pagenotfound} URL (as a string).
+     *
+     * @param requestContext the {@link HstRequestContext} instance.
+     * @param mount          the {@link Mount} instance.
+     * @param fullyQualified boolean indicating whether to return fully qualified URL or not.
+     * @return {@code pagenotfound} URL (as a string).
+     */
+    public static String getPageNotFoundURL(
+            final HstRequestContext requestContext,
+            final Mount mount,
+            final boolean fullyQualified
+    ) {
+        final HstLink pageNotFoundLink = getPageNotFoundLink(requestContext, mount);
+
+        if (pageNotFoundLink == null) {
+            LOGGER.error("'pagenotfound' hst:sitemapitem hasn't been configured. Please verify.");
+            return null;
+        }
+
+        return pageNotFoundLink.toUrlForm(requestContext, fullyQualified);
+    }
+
+    /**
+     * Returns {@code true} if the given {@code link} is a {@code pagenotfound} link.
+     * Otherwise, returns {@code false}.
+     *
+     * @param link           the {@link HstLink} instance which needs to be verified
+     *                       if it is {@code pagenotfound} link or not.
+     * @param fullyQualified boolean indicating that the given {@code link} is a fully-qualified one.
+     * @param requestContext the {@link HstRequestContext} instance.
+     * @param mount          the {@link Mount} instance.
+     * @return {@code true} if the given {@code link} is a {@code pagenotfound} link. Otherwise, returns {@code false}.
+     */
+    public static boolean isPageNotFound(
+            final HstLink link,
+            final boolean fullyQualified,
+            final HstRequestContext requestContext,
+            final Mount mount
+    ) {
+        return isPageNotFound(link.toUrlForm(requestContext, fullyQualified), fullyQualified, requestContext, mount);
+    }
+
+    /**
+     * Returns {@code true} if the given {@code url} is a {@code pagenotfound} URL.
+     * Otherwise, returns {@code false}.
+     *
+     * @param url            the URL string which needs to be verified if it is a {@code pagenotfound} URL or not.
+     * @param fullyQualified boolean indicating that the given {@code link} is a fully-qualified one.
+     * @param requestContext the {@link HstRequestContext} instance.
+     * @param mount          the {@link Mount} instance.
+     * @return {@code true} if the given {@code url} is a {@code pagenotfound} URL.
+     * Otherwise, returns {@code false}.
+     */
+    public static boolean isPageNotFound(
+            final String url,
+            final boolean fullyQualified,
+            final HstRequestContext requestContext,
+            final Mount mount
+    ) {
+        final HstLink pageNotFoundLink = getPageNotFoundLink(requestContext, mount);
+
+        if (pageNotFoundLink == null) {
+            LOGGER.error("'pagenotfound' hst:sitemapitem hasn't been configured. Please verify.");
+            return false;
+        }
+
+        return pageNotFoundLink.toUrlForm(requestContext, fullyQualified).equals(url);
+    }
+
+    /**
      * Returns {@link HippoBean} corresponding to the given {@code listingType}.
      *
      * @param requestContext the {@link HstRequestContext} instance.
-     * @param listingType the Listing Page Type.
+     * @param listingType    the Listing Page Type.
      * @return the {@link HippoBean} corresponding to the given {@code listingType}.
      */
     public static HippoBean getListingPageBeanByType(final HstRequestContext requestContext, final String listingType) {

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/MiniHubGuidanceLinkUtils.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/MiniHubGuidanceLinkUtils.java
@@ -1,0 +1,176 @@
+package uk.nhs.hee.web.utils;
+
+import org.hippoecm.hst.configuration.hosting.Mount;
+import org.hippoecm.hst.core.linking.HstLink;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+
+/**
+ * A utility class providing method(s) to generate Mini-hub Guidance page links (in case if any)
+ * for the given Guidance nodes.
+ */
+public class MiniHubGuidanceLinkUtils {
+    /**
+     * XPath query to find the first MiniHub ({@code hee:MiniHub}) document Handle node
+     * to which a given Guidance document ({@code guidanceUUID}) has been associated.
+     */
+    public static final String REFERENCED_MINI_HUB_NODE_FINDER_QUERY =
+            "/jcr:root/%s//element(*, hee:MiniHub)[@hippo:availability='%s']" +
+                    "/hee:guidancePages[(@jcr:primaryType='hippo:mirror') and (@hippo:docbase='%s')]/..";
+    private static final Logger log = LoggerFactory.getLogger(MiniHubGuidanceLinkUtils.class);
+    private static final String GUIDANCE_DOCUMENT_TYPE = "hee:guidance";
+    private static final String AVAILABILITY_PREVIEW = "preview";
+    private static final String AVAILABILITY_LIVE = "live";
+
+    /**
+     * Private constructor to restrict instantiating this utility class.
+     */
+    private MiniHubGuidanceLinkUtils() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Returns {@link HstLink} instance (in {@code {mini-hub_URL}/{guidance_node_name}} format)
+     * for the given ({@code hee:guidance}) document node.
+     *
+     * @param node the ({@code hee:guidance}) {@link Node} instance.
+     * @param canonical boolean indicating whether canonical link should be returned or not.
+     * @param requestContext the {@link HstRequestContext} instance.
+     * @param mount the {@link Mount} instance.
+     * @return {@link HstLink} instance (in {@code {mini-hub_URL}/{guidance_node_name}} format)
+     * for the given ({@code hee:guidance}) document node.
+     */
+    public static HstLink getLink(
+            final Node node,
+            final boolean canonical,
+            final HstRequestContext requestContext,
+            final Mount mount
+    ) {
+        try {
+            if (!isGuidance(node)) {
+                log.debug("'{}' isn't a Guidance ({}) document", node.getPath(), GUIDANCE_DOCUMENT_TYPE);
+                return null;
+            }
+
+            log.debug("'{}' is a Guidance ({}) document", node.getPath(), GUIDANCE_DOCUMENT_TYPE);
+
+            final Node miniHubNode =
+                    getReferencedMiniHubNode(requestContext, requestContext.getSiteContentBasePath(), node.getIdentifier());
+
+            if (miniHubNode == null) {
+                log.debug("Guidance node with UUID '{}' and path '{}' hasn't been associated to any Mini-hub page(s)",
+                        node.getIdentifier(), node.getPath());
+                return null;
+            }
+
+            log.debug("Guidance node with UUID '{}' and path '{}' has been associated to the Mini-hub page = {}",
+                    node.getIdentifier(), node.getPath(), miniHubNode.getPath());
+
+            final HstLink miniHubGuidanceLink = createInternalLink(miniHubNode, canonical, requestContext, mount);
+            // Mini-hub Guidance URL format: {mini-hub_URL}/{guidance_node_name}
+            final String miniHubGuidanceURL = miniHubGuidanceLink.getPath() + "/" + node.getName();
+            log.debug("URL generated for the Guidance node with UUID '{}' and path '{}' " +
+                            "(based on the referenced Mini-hub URL '{}') = {}",
+                    node.getIdentifier(), node.getPath(), miniHubGuidanceLink.getPath(), miniHubGuidanceURL);
+
+            miniHubGuidanceLink.setPath(miniHubGuidanceURL);
+            return miniHubGuidanceLink;
+        } catch (final Exception e) {
+            log.error("Caught error '{}' while rewriting link for Mini-hub Guidance documents", e.getMessage(), e);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if child node of the given {@code handleNode} is a Guidance document ({@code hee:guidance}).
+     * Otherwise, returns {@code false}.
+     *
+     * @param handleNode the Handle {@link Node} instance.
+     * @return {@code true} if child node of the given {@code handleNode} is a Guidance document ({@code hee:guidance}).
+     * @throws RepositoryException thrown when an error occurs while working with {@code handleNode}.
+     */
+    private static boolean isGuidance(final Node handleNode) throws RepositoryException {
+        final NodeIterator childNodeIterator = handleNode.getNodes();
+        return childNodeIterator.hasNext() && childNodeIterator.nextNode().isNodeType(GUIDANCE_DOCUMENT_TYPE);
+    }
+
+    /**
+     * Returns the first MiniHub ({@code hee:MiniHub}) document Handle node
+     * to which the given Guidance document ({@code guidanceUUID}) has been associated. Otherwise, returns {@code null}.
+     *
+     * @param requestContext the {@link HstRequestContext} instance.
+     * @param contentPath    the (channel) content path under which the referenced MiniHub document
+     *                       needs to be searched for.
+     * @param guidanceUUID   the UUID of the Guidance Handle node.
+     * @return the first MiniHub ({@code hee:MiniHub}) document Handle node
+     * to which the given Guidance document ({@code guidanceUUID}) has been associated. Otherwise, returns {@code null}.
+     * @throws RepositoryException thrown when an error occurs while searching for referenced MiniHub in the repository.
+     */
+    private static Node getReferencedMiniHubNode(
+            final HstRequestContext requestContext,
+            final String contentPath,
+            final String guidanceUUID) throws RepositoryException {
+        final String formattedReferencedMiniHubNodeFinderQuery = String.format(REFERENCED_MINI_HUB_NODE_FINDER_QUERY,
+                contentPath,
+                requestContext.isChannelManagerPreviewRequest() ? AVAILABILITY_PREVIEW : AVAILABILITY_LIVE,
+                guidanceUUID);
+
+        log.debug("Formatted referenced Mini-hub (hee:MiniHub) node finder query = {}",
+                formattedReferencedMiniHubNodeFinderQuery);
+
+        final Query referencedMiniHubNodeFinderQuery =
+                requestContext.getQueryManager().getSession().getWorkspace().getQueryManager().createQuery(
+                        formattedReferencedMiniHubNodeFinderQuery,
+                        Query.XPATH
+                );
+        final QueryResult results = referencedMiniHubNodeFinderQuery.execute();
+        final NodeIterator nodeIterator = results.getNodes();
+
+        if (nodeIterator.hasNext()) {
+            return nodeIterator.nextNode();
+        }
+
+        return null;
+    }
+
+    /**
+     * Create an HstLink to a referenced node in rich text.
+     *
+     * @param referencedNode the node to create a link to
+     * @param requestContext the context for the current request
+     * @param targetMount    mount that the link by preference points to. may be null. If not null, a link for a different
+     *                       {@link Mount} might be returned
+     * @return link to the referenced node and optional target mount. target mount is ignored in case links must be canonical.
+     * @throws RepositoryException if no path can be retrieved from the referencedNode
+     */
+    protected static HstLink createInternalLink(
+            final Node referencedNode,
+            final boolean canonical,
+            final HstRequestContext requestContext,
+            final Mount targetMount
+    ) throws RepositoryException {
+        if (canonical) {
+            if (targetMount != null) {
+                log.info("TargetMount is defined to create a link for, but target mount is ignored in case a canonical link is " +
+                                "requested. Ignoring target mount '{}' but instead return canonical link for nodepath '{}'.",
+                        targetMount, referencedNode.getPath());
+            }
+            return requestContext.getHstLinkCreator().createCanonical(referencedNode, requestContext);
+        }
+
+        if (targetMount == null) {
+            return requestContext.getHstLinkCreator().create(referencedNode, requestContext);
+        } else {
+            return requestContext.getHstLinkCreator().create(referencedNode, targetMount, true);
+        }
+    }
+
+}

--- a/site/components/src/main/resources/META-INF/hst-custom.tld
+++ b/site/components/src/main/resources/META-INF/hst-custom.tld
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<taglib xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
+        version="2.1"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd">
+
+  <description>HST Custom Tag Library</description>
+  <tlib-version>1.0</tlib-version>
+  <short-name>hst-custom-tags</short-name>
+  <uri>http://www.hippoecm.org/jsp/hst/custom</uri>
+
+  <tag>
+    <description>An extension of OOTB HST core &lt;hst:link/&gt; tag to generate URL(s) for Mini-Hub Guidance document(s). Note that the tag (&lt;hstCustom:link/&gt;) supports 'hippobean' attribute only and so continue to use OOTB core &lt;hst:link/&gt; tag to generate links based on other attributes. Refer https://javadoc.onehippo.org/14.7/tlddocs/hst-core-tags/link.html for more details on the OOTB &lt;hst:link/&gt; tag.</description>
+    <name>getMiniHubGuidanceLink</name>
+    <tag-class>uk.nhs.hee.web.tag.GetMiniHubGuidanceLink</tag-class>
+    <tei-class>uk.nhs.hee.web.tag.GetMiniHubGuidanceLink$TEI</tei-class>
+    <body-content>JSP</body-content>
+    <attribute>
+      <description>The variable name of the link tag</description>
+      <name>var</name>
+      <required>false</required>
+      <rtexprvalue>false</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
+      <description>An IdentifiableContentBean object. This is typically one of your bean mapped objects</description>
+      <name>hippobean</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>org.hippoecm.hst.content.beans.standard.IdentifiableContentBean</type>
+    </attribute>
+    <attribute>
+      <description>If value is 'true' the created link will be a fully qualified link (URLs), thus starting with
+        'http://' or 'https://' etc</description>
+      <name>fullyQualified</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.Boolean</type>
+    </attribute>
+    <attribute>
+      <description>If the link that is created should be the canonical link, use this attr with value true</description>
+      <name>canonical</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.Boolean</type>
+    </attribute>
+    <attribute>
+      <description>Whether or not to escape &amp;,&gt;,&lt;,", and '. When escapeXml = true, the link can be safely used as a tag attribute (e.g, href, src, etc.) value. By default escapeXml is set to true.</description>
+      <name>escapeXml</name>
+      <required>false</required>
+      <rtexprvalue>false</rtexprvalue>
+      <type>java.lang.Boolean</type>
+    </attribute>
+    <attribute>
+      <description>Scope of var or the localization context configuration variable. "page", "request", "session" or "application". "page" scope by default.</description>
+      <name>scope</name>
+      <required>false</required>
+      <rtexprvalue>false</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <example><![CDATA[
+    <!-- In a body component: A list of document names with summaries and links to those documents: -->
+
+     <c:forEach var="child_document" items="${document_list}">
+       <tr>
+         <hstCustom:getMiniHubGuidanceLink var="link" hippobean="${child_document}"/>
+         <td class="title">
+           <a href="${link}">${child_document.name}</a>
+         </td>
+         <td>${child_document.summary}</td>
+       </tr>
+     </c:forEach>
+
+     <!-- Refer https://javadoc.onehippo.org/14.7/tlddocs/hst-core-tags/link.html for more details on the OOTB <hst:link/> usage -->
+
+     ]]></example>
+  </tag>
+
+</taglib>

--- a/site/components/src/test/java/uk/nhs/hee/web/content/rewriter/impl/MiniHubGuidanceLinkRewriterTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/content/rewriter/impl/MiniHubGuidanceLinkRewriterTest.java
@@ -1,7 +1,6 @@
 package uk.nhs.hee.web.content.rewriter.impl;
 
 import org.hippoecm.hst.configuration.hosting.Mount;
-import org.hippoecm.hst.content.beans.query.HstQueryManager;
 import org.hippoecm.hst.core.linking.HstLink;
 import org.hippoecm.hst.core.request.HstRequestContext;
 import org.hippoecm.repository.api.HippoNodeType;
@@ -11,20 +10,25 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import uk.nhs.hee.web.utils.HstUtils;
+import uk.nhs.hee.web.utils.MiniHubGuidanceLinkUtils;
 
 import javax.jcr.*;
 import javax.jcr.nodetype.NodeType;
-import javax.jcr.query.Query;
-import javax.jcr.query.QueryManager;
-import javax.jcr.query.QueryResult;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
+@PrepareForTest({
+        MiniHubGuidanceLinkUtils.class,
+        HstUtils.class
+})
 @PowerMockIgnore({"javax.management.*", "javax.script.*"})
 public class MiniHubGuidanceLinkRewriterTest {
     @Mock
@@ -33,8 +37,20 @@ public class MiniHubGuidanceLinkRewriterTest {
     private HstRequestContext mockHstRequestContext;
     @Mock
     private HstLink mockSuperClassLink;
+    @Spy
+    private final MiniHubGuidanceLinkRewriter systemUnderTest = new MiniHubGuidanceLinkRewriter() {
+        @Override
+        protected HstLink createInternalLink(
+                final Node referencedNode,
+                final HstRequestContext requestContext,
+                final Mount targetMount) {
+
+            return mockSuperClassLink;
+        }
+    };
+
     @Mock
-    private HstLink mockMiniHubLink;
+    private HstLink mockMiniHubGuidanceLink;
     @Mock
     private Node mockHtmlNode;
     @Mock
@@ -43,20 +59,6 @@ public class MiniHubGuidanceLinkRewriterTest {
     private Node mockReferencedNode;
     @Mock
     private Node mockMiniHubNode;
-    @Spy
-    private final MiniHubGuidanceLinkRewriter systemUnderTest = new MiniHubGuidanceLinkRewriter() {
-        @Override
-        protected HstLink createInternalLink(
-                final Node referencedNode,
-                final HstRequestContext requestContext,
-                final Mount targetMount) {
-            if (referencedNode == mockMiniHubNode) {
-                return mockMiniHubLink;
-            }
-
-            return mockSuperClassLink;
-        }
-    };
     @Mock
     private Node mockDocumentNode;
     @Mock
@@ -66,6 +68,10 @@ public class MiniHubGuidanceLinkRewriterTest {
 
     @Before
     public void setUp() throws Exception {
+        mockStatic(MiniHubGuidanceLinkUtils.class, HstUtils.class);
+        when(HstUtils.isPageNotFound(any(HstLink.class), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
+                .thenReturn(true);
+
         when(mockSuperClassLink.getPath()).thenReturn("pagenotfound");
 
         when(mockHtmlNode.getNode(anyString())).thenReturn(mockMirrorNode);
@@ -88,43 +94,24 @@ public class MiniHubGuidanceLinkRewriterTest {
         final String referencedNodeName = "introduction";
         when(mockReferencedNode.getName()).thenReturn(referencedNodeName);
         when(mockReferencedNode.hasNode(referencedNodeName)).thenReturn(true);
-
-        final NodeIterator mockChildNodeIterator = mock(NodeIterator.class);
-        when(mockReferencedNode.getNodes()).thenReturn(mockChildNodeIterator);
-        when(mockChildNodeIterator.hasNext()).thenReturn(true);
-        when(mockChildNodeIterator.nextNode()).thenReturn(mockDocumentNode);
-        when(mockDocumentNode.isNodeType("hee:guidance")).thenReturn(true);
-
-        when(mockHstRequestContext.getSiteContentBasePath()).thenReturn("/content/documents/lks");
-        when(mockHstRequestContext.isChannelManagerPreviewRequest()).thenReturn(false);
-        final HstQueryManager mockHstQueryManager = mock(HstQueryManager.class);
-        when(mockHstRequestContext.getQueryManager()).thenReturn(mockHstQueryManager);
-        when(mockHstQueryManager.getSession()).thenReturn(mockJCRSession);
-        final Workspace mockWorkspace = mock(Workspace.class);
-        when(mockJCRSession.getWorkspace()).thenReturn(mockWorkspace);
-        final QueryManager mockQueryManager = mock(QueryManager.class);
-        when(mockWorkspace.getQueryManager()).thenReturn(mockQueryManager);
-        final Query mockQuery = mock(Query.class);
-        when(mockQueryManager.createQuery(anyString(), eq(Query.XPATH))).thenReturn(mockQuery);
-        final QueryResult mockQueryResult = mock(QueryResult.class);
-        when(mockQuery.execute()).thenReturn(mockQueryResult);
-        when(mockQueryResult.getNodes()).thenReturn(mockMiniHubNodeIterator);
-        when(mockMiniHubNodeIterator.hasNext()).thenReturn(true);
-        when(mockMiniHubNodeIterator.nextNode()).thenReturn(mockMiniHubNode);
-        when(mockMiniHubLink.getPath()).thenReturn("patient-and-public-information");
     }
 
     @Test
     public void getLink_WithLinkFromSuperClassIsNotPageNotFound_ReturnsLinkFromSuperClass() {
         // Mocks & stubs
         when(mockSuperClassLink.getPath()).thenReturn("copyright");
+        when(HstUtils.isPageNotFound(any(HstLink.class), anyBoolean(), eq(mockHstRequestContext), any(Mount.class)))
+                .thenReturn(false);
 
         // Execute the method to be tested
         final HstLink hstLink = systemUnderTest.getLink(
                 "copyright", mockHtmlNode, mockHstRequestContext, mock(Mount.class));
 
         // Verify
-        assertThat(hstLink).isEqualTo(mockSuperClassLink);
+        assertThat(hstLink).satisfiesAnyOf(
+                link -> assertThat(link).isNull(),
+                link -> assertThat(link).isEqualTo(mockSuperClassLink)
+        );
     }
 
     @Test
@@ -139,7 +126,7 @@ public class MiniHubGuidanceLinkRewriterTest {
         // Verify
         assertThat(hstLink).satisfiesAnyOf(
                 link -> assertThat(link).isNull(),
-                link -> assertThat(link.getPath()).isEqualTo("pagenotfound")
+                link -> assertThat(link).isEqualTo(mockSuperClassLink)
         );
     }
 
@@ -156,7 +143,7 @@ public class MiniHubGuidanceLinkRewriterTest {
         // Verify
         assertThat(hstLink).satisfiesAnyOf(
                 link -> assertThat(link).isNull(),
-                link -> assertThat(link.getPath()).isEqualTo("pagenotfound")
+                link -> assertThat(link).isEqualTo(mockSuperClassLink)
         );
     }
 
@@ -173,7 +160,7 @@ public class MiniHubGuidanceLinkRewriterTest {
         // Verify
         assertThat(hstLink).satisfiesAnyOf(
                 link -> assertThat(link).isNull(),
-                link -> assertThat(link.getPath()).isEqualTo("pagenotfound")
+                link -> assertThat(link).isEqualTo(mockSuperClassLink)
         );
     }
 
@@ -190,7 +177,7 @@ public class MiniHubGuidanceLinkRewriterTest {
         // Verify
         assertThat(hstLink).satisfiesAnyOf(
                 link -> assertThat(link).isNull(),
-                link -> assertThat(link.getPath()).isEqualTo("pagenotfound")
+                link -> assertThat(link).isEqualTo(mockSuperClassLink)
         );
     }
 
@@ -199,6 +186,8 @@ public class MiniHubGuidanceLinkRewriterTest {
             throws RepositoryException {
         // Mocks & stubs
         when(mockDocumentNode.isNodeType("hee:guidance")).thenReturn(false);
+        when(MiniHubGuidanceLinkUtils.getLink(eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext),
+                any(Mount.class))).thenReturn(null);
 
         // Execute the method to be tested
         final HstLink hstLink = systemUnderTest.getLink(
@@ -207,7 +196,7 @@ public class MiniHubGuidanceLinkRewriterTest {
         // Verify
         assertThat(hstLink).satisfiesAnyOf(
                 link -> assertThat(link).isNull(),
-                link -> assertThat(link.getPath()).isEqualTo("pagenotfound")
+                link -> assertThat(link).isEqualTo(mockSuperClassLink)
         );
     }
 
@@ -215,6 +204,8 @@ public class MiniHubGuidanceLinkRewriterTest {
     public void getLink_WithReferencedGuidanceNodeNotAssociatedToAnyMiniHubDocument_ReturnsLinkFromSuperClass() {
         // Mocks & stubs
         when(mockMiniHubNodeIterator.hasNext()).thenReturn(false);
+        when(MiniHubGuidanceLinkUtils.getLink(eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext),
+                any(Mount.class))).thenReturn(null);
 
         // Execute the method to be tested
         final HstLink hstLink = systemUnderTest.getLink(
@@ -223,19 +214,22 @@ public class MiniHubGuidanceLinkRewriterTest {
         // Verify
         assertThat(hstLink).satisfiesAnyOf(
                 link -> assertThat(link).isNull(),
-                link -> assertThat(link.getPath()).isEqualTo("pagenotfound")
+                link -> assertThat(link).isEqualTo(mockSuperClassLink)
         );
     }
 
     @Test
     public void getLink_WithReferencedGuidanceNodeAssociatedToAMiniHubDocument_ReturnsLinkFromSuperClass() {
+        // Mocks & stubs
+        when(MiniHubGuidanceLinkUtils.getLink(eq(mockReferencedNode), anyBoolean(), eq(mockHstRequestContext),
+                any(Mount.class))).thenReturn(mockMiniHubGuidanceLink);
+
         // Execute the method to be tested
         final HstLink hstLink = systemUnderTest.getLink(
                 "path_with_valid_handle_node", mockHtmlNode, mockHstRequestContext, mock(Mount.class));
 
         // Verify
-        assertThat(hstLink).isEqualTo(mockMiniHubLink);
-        verify(hstLink, times(1)).setPath("patient-and-public-information/introduction");
+        assertThat(hstLink).isEqualTo(mockMiniHubGuidanceLink);
     }
 
 }


### PR DESCRIPTION
- Build `<heeCustom:link/>` custom link tag to generate Minihub Guidance link(s) from freemarker templates.
- Refactored `uk.nhs.hee.web.content.rewriter.impl.MiniHubGuidanceLinkRewriter` so that the logic to generate Minihub Guidance link(s) could be reused in the custom tag class `uk.nhs.hee.web.tag.GetMiniHubGuidanceLink`.
- Updated freemarker templates to use `<heeCustom:link/>` tag to try generating MiniHub Guidance link in case if they end up with `pagenotfound` for a Guidance document.