### PR TITLE
NWPS-970: brXM upgrade from 14.7.3 to 14.7.8

### DIFF
--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -111,4 +111,4 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-smtp.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -103,7 +103,7 @@ jobs:
           distPath: ${{ steps.dist.outputs.distPath }}
 
       - name: Deploy distribution to 'production' env
-        uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.2
+        uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.2.1
         id: deploy
         with:
           brcStack: ${{ env.BRC_STACK_NAME }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -100,7 +100,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
       - name: Deploy distribution to 'development' env
-        uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.2
+        uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.2.1
         id: deploy
         with:
           brcStack: ${{ env.BRC_STACK_NAME }}
@@ -169,7 +169,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
       - name: Deploy distribution to 'test' env
-        uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.2
+        uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.2.1
         id: deploy
         with:
           brcStack: ${{ env.BRC_STACK_NAME }}
@@ -238,7 +238,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distPath: ${{ steps.dist.outputs.distPath }}
       - name: Deploy distribution to 'staging' env
-        uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.2
+        uses: Health-Education-England/deploy-distribution-to-BR-Cloud-action@v1.2.1
         id: deploy
         with:
           brcStack: ${{ env.BRC_STACK_NAME }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -108,7 +108,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-smtp.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'
 
   deploy-to-test:
     name: Deploy to Test Env. [on brCloud]
@@ -177,7 +177,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-smtp.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'
 
   deploy-to-staging:
     name: Deploy to Staging Env. [on brCloud]
@@ -246,4 +246,4 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-smtp.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The HEE CMS Platform used to manage and deliver the website at https://www.hee.n
 
 ## Built With
 
-* [BloomReach DXP 14.7.3](http://www.bloomreach.com) - BloomReach is the content management system platform used in this project
+* [BloomReach DXP 14.7.8](http://www.bloomreach.com) - BloomReach is the content management system platform used in this project
 * [brCloud](https://www.bloomreach.com/en/products/experience-manager/cloud-cms) - Bloomreach Cloud Managed Hosting
 
 ## Getting Started

--- a/conf/hee-platform.properties
+++ b/conf/hee-platform.properties
@@ -1,0 +1,6 @@
+# Note that this file needs to be uploaded to brCloud dashboard manually when a change has been made so as to avoid uploading it during every CICD as this file gets modified occasionally.
+
+# Enables "Log Target" feature for non-local environments (to choose whether to log execution output on "Repository" or "Log Files") for updater scripts.
+# Refer "Log Target" section on
+# https://xmdocumentation.bloomreach.com/library/concepts/update/run-an-updater-script.html#scroll_execution-options for more details.
+groovy.persist.logs.supported=true

--- a/conf/log4j2-dev.xml
+++ b/conf/log4j2-dev.xml
@@ -146,6 +146,8 @@
 
     <!-- project logging -->
     <Logger name="uk.nhs.hee.web" level="debug"/>
+    <!-- Added this as part of 14.7.3 to 14.7.8 to log updater script execution INFO output in case if the script has been run using "Log Files" Log Target -->
+    <Logger name="org.onehippo.repository.update.UpdaterExecutionReport" level="info"/>
     <Logger name="org.hippoecm.hst.core.container.DefaultPageErrorHandler" level="debug"/>
 
     <Root level="warn">

--- a/conf/log4j2-dist.xml
+++ b/conf/log4j2-dist.xml
@@ -103,6 +103,8 @@
 
     <!-- project logging -->
     <Logger name="uk.nhs.hee.web" level="info"/>
+    <!-- Added this as part of 14.7.3 to 14.7.8 to log updater script execution INFO output in case if the script has been run using "Log Files" Log Target -->
+    <Logger name="org.onehippo.repository.update.UpdaterExecutionReport" level="info"/>
 
     <Root level="warn">
       <AppenderRef ref="site"/>

--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,11 @@
                   <project.basedir>${project.basedir}</project.basedir>
                   <send.usage.statistics.to.hippo>true</send.usage.statistics.to.hippo>
 
+                  <!-- Enables "Log Target" feature (to choose whether to log execution output on "Repository" or on "Log Files") for updater scripts. -->
+                  <!-- Refer "Log Target" section on https://xmdocumentation.bloomreach.com/library/concepts/update/run-an-updater-script.html#scroll_execution-options for more details. -->
+                  <!-- Note that "Log Target" is enabled by default for local environments and so "groovy.persist.logs.supported" property doesn't requires to be setting, but adding here for completeness. -->
+                  <groovy.persist.logs.supported>true</groovy.persist.logs.supported>
+
                   <!-- Example to pass JavaMail connection factory JNDI resource attribute values as system properties -->
                   <!-- Alternatively these could directly be configured on 'conf/context-dev.xml'  -->
                   <!-- <mail.smtp.host><<mail.smtp.host>></mail.smtp.host></mail.smtp.host>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-enterprise-release</artifactId>
-    <version>14.7.3</version>
+    <version>14.7.8</version>
   </parent>
 
   <name>HEE CMS Platform</name>
@@ -64,7 +64,7 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
 
-    <essentials.version>14.7.3</essentials.version>
+    <essentials.version>14.7.8</essentials.version>
     <jsp-api.version>2.2</jsp-api.version>
     <taglibs.version>1.2.5</taglibs.version>
     <freemarker.version>2.3.29</freemarker.version>

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/forms.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/forms.yaml
@@ -404,8 +404,8 @@
         eforms:notificationccemail: ''
         eforms:notificationreplytoemailfields: ''
         eforms:notificationsubject: Blog comment moderation notification
-        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.7.3]\
-          \ com.onehippo.cms7:hippo-addon-eforms:14.7.3:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
+        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.7.8]\
+          \ com.onehippo.cms7:hippo-addon-eforms:14.7.8:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
           \n  -->\r\n<#-- @ftlvariable name=\"form\" type=\"com.onehippo.cms7.eforms.hst.model.Form\"\
           \ -->\r\n<#-- @ftlvariable name=\"paragraph\" type=\"java.lang.String\"\
           \ -->\r\n<#-- @ftlvariable name=\"includeFieldData\" type=\"java.lang.Boolean\"\
@@ -567,8 +567,8 @@
         eforms:notificationccemail: ''
         eforms:notificationreplytoemailfields: ''
         eforms:notificationsubject: Blog comment moderation notification
-        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.7.3]\
-          \ com.onehippo.cms7:hippo-addon-eforms:14.7.3:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
+        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.7.8]\
+          \ com.onehippo.cms7:hippo-addon-eforms:14.7.8:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
           \n  -->\r\n<#-- @ftlvariable name=\"form\" type=\"com.onehippo.cms7.eforms.hst.model.Form\"\
           \ -->\r\n<#-- @ftlvariable name=\"paragraph\" type=\"java.lang.String\"\
           \ -->\r\n<#-- @ftlvariable name=\"includeFieldData\" type=\"java.lang.Boolean\"\
@@ -731,8 +731,8 @@
         eforms:notificationccemail: ''
         eforms:notificationreplytoemailfields: ''
         eforms:notificationsubject: Blog comment moderation notification
-        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.7.3]\
-          \ com.onehippo.cms7:hippo-addon-eforms:14.7.3:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
+        eforms:notificationtemplate: "<#--\r\n  Extended from [hippo-addon-eforms-hst-14.7.8]\
+          \ com.onehippo.cms7:hippo-addon-eforms:14.7.8:com/onehippo/cms7/eforms/hst/templates/email/eforms_html.ftl\r\
           \n  -->\r\n<#-- @ftlvariable name=\"form\" type=\"com.onehippo.cms7.eforms.hst.model.Form\"\
           \ -->\r\n<#-- @ftlvariable name=\"paragraph\" type=\"java.lang.String\"\
           \ -->\r\n<#-- @ftlvariable name=\"includeFieldData\" type=\"java.lang.Boolean\"\


### PR DESCRIPTION
**Verification:**
- On the CMS side, have verified Content management [`content`], Channel & page management [`Experience manager`], User management [`Setup -> brXM User management`], Groovy scripts [`Setup -> System -> Update editor`].
- On the Site side, have verified Channel virtual hosts and their pages.
- Have also verified Console and Repository applications.

*Log Target* feature support:
- Updated CICD workflow files to deploy `conf/context.xml` file additionally as Java System Properties (containing `groovy.persist.logs.supported=true` property) to enable `Log Target` feature for updater (groovy) scripts for non-local environments.
- Added `org.onehippo.repository.update.UpdaterExecutionReport` INFO logger to log updater (groovy) script outputs on `Log Files`.