### PR TITLE
NWPS-943: Fix for "channel with duplicate id" error

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
@@ -8,11 +8,12 @@ definitions:
           /pagenotfound:
             jcr:primaryType: hst:sitemapitem
             hst:componentconfigurationid: hst:pages/pagenotfound
-            hst:pagetitle: Not Found Page
+            hst:pagetitle: Page not found
             hst:refId: pagenotfound
           /_any_:
             jcr:primaryType: hst:sitemapitem
             hst:componentconfigurationid: hst:pages/pagenotfound
+            hst:pagetitle: Page not found
           /root:
             jcr:primaryType: hst:sitemapitem
             hst:componentconfigurationid: hst:pages/homepage

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-live-redirect.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-live-redirect.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/prd-live-redirect:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 8080

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-live-redirect/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-live-redirect/uk.yaml
@@ -1,0 +1,37 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/prd-live-redirect/uk:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhost
+      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''', 'X-Frame-Options:
+          SAMEORIGIN']
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        .meta:residual-child-node-category: content
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:virtualhost
+          /gprecruitment:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /hst:root:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:mount
+              hst:homepage: root
+              hst:locale: en
+              hst:mountpoint: /hst:hee/hst:sites/medical
+        /libraryservices:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:virtualhost
+          /kfh:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /hst:root:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:mount
+              hst:homepage: root
+              hst:locale: en
+              hst:mountpoint: /hst:hee/hst:sites/lks

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-live.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-live.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/prd-live:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 8080

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-live/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-live/uk.yaml
@@ -1,13 +1,13 @@
 definitions:
   config:
-    /hst:hst/hst:hosts/prd-brcloud/uk:
+    /hst:hst/hst:hosts/prd-live/uk:
       .meta:residual-child-node-category: content
       jcr:primaryType: hst:virtualhost
+      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''', 'X-Frame-Options:
+          SAMEORIGIN']
       hst:scheme: https
       hst:showcontextpath: false
       hst:showport: false
-      hst:responseheaders: ['Content-Security-Policy: frame-ancestors ''self''', 'X-Frame-Options:
-          SAMEORIGIN']
       /nhs:
         .meta:residual-child-node-category: content
         jcr:primaryType: hst:virtualhost
@@ -23,7 +23,6 @@ definitions:
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/lks
-              hst:nochannelinfo: true
               /preview:
                 .meta:residual-child-node-category: content
                 jcr:primaryType: hst:mount
@@ -39,7 +38,6 @@ definitions:
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/dental
-              hst:nochannelinfo: true
               /preview:
                 .meta:residual-child-node-category: content
                 jcr:primaryType: hst:mount
@@ -55,7 +53,6 @@ definitions:
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/digital-transformation
-              hst:nochannelinfo: true
               /preview:
                 .meta:residual-child-node-category: content
                 jcr:primaryType: hst:mount
@@ -71,7 +68,6 @@ definitions:
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/medical
-              hst:nochannelinfo: true
               /preview:
                 .meta:residual-child-node-category: content
                 jcr:primaryType: hst:mount
@@ -84,12 +80,11 @@ definitions:
             /hst:root:
               .meta:residual-child-node-category: content
               jcr:primaryType: hst:mount
+              hst:authenticated: true
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/quality
-              hst:nochannelinfo: true
-              hst:roles: [site.viewer]
-              hst:authenticated: true
+              hst:roles: site.viewer
               /preview:
                 .meta:residual-child-node-category: content
                 jcr:primaryType: hst:mount
@@ -102,41 +97,17 @@ definitions:
             /hst:root:
               .meta:residual-child-node-category: content
               jcr:primaryType: hst:mount
+              hst:authenticated: true
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/website-testing
               hst:responseheaders: ['robots: noindex, nofollow', 'Content-Security-Policy:
                   frame-ancestors ''self''', 'X-Frame-Options: SAMEORIGIN']
               hst:roles: [site.viewer]
-              hst:authenticated: true
-              hst:nochannelinfo: true
               /preview:
                 .meta:residual-child-node-category: content
                 jcr:primaryType: hst:mount
                 hst:type: preview
-          /gprecruitment:
-            .meta:residual-child-node-category: content
-            jcr:primaryType: hst:virtualhost
-            /hst:root:
-              .meta:residual-child-node-category: content
-              jcr:primaryType: hst:mount
-              hst:homepage: root
-              hst:locale: en
-              hst:mountpoint: /hst:hee/hst:sites/medical
-              hst:nochannelinfo: true
-        /libraryservices:
-          .meta:residual-child-node-category: content
-          jcr:primaryType: hst:virtualhost
-          /kfh:
-            .meta:residual-child-node-category: content
-            jcr:primaryType: hst:virtualhost
-            /hst:root:
-              .meta:residual-child-node-category: content
-              jcr:primaryType: hst:mount
-              hst:homepage: root
-              hst:locale: en
-              hst:mountpoint: /hst:hee/hst:sites/lks
-              hst:nochannelinfo: true
         /healthcareers:
           .meta:residual-child-node-category: content
           jcr:primaryType: hst:virtualhost
@@ -146,12 +117,11 @@ definitions:
             /hst:root:
               .meta:residual-child-node-category: content
               jcr:primaryType: hst:mount
+              hst:authenticated: true
               hst:homepage: root
               hst:locale: en
               hst:mountpoint: /hst:hee/hst:sites/health-careers
-              hst:nochannelinfo: true
               hst:roles: [site.viewer]
-              hst:authenticated: true
               /preview:
                 .meta:residual-child-node-category: content
                 jcr:primaryType: hst:mount

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-layout.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-layout.ftl
@@ -5,7 +5,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <title>${hstRequestContext.resolvedSiteMapItem.pageTitle?has_content?then(hstRequestContext.resolvedSiteMapItem.pageTitle, hstRequestContext.contentBean.title?has_content?then(hstRequestContext.contentBean.title, document.title?has_content?then(document.title, '')))} | ${hstRequestContext.resolvedMount.mount.channelInfo.organisationDescriptor}</title>
+    <title>${hstRequestContext.resolvedSiteMapItem.pageTitle?has_content?then(hstRequestContext.resolvedSiteMapItem.pageTitle, document.title!)} | ${hstRequestContext.resolvedMount.mount.channelInfo.organisationDescriptor}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 


### PR DESCRIPTION
- Separated out live site vhosts under `prd-live`.
- Separated out live site redirect vhosts under `prd-live-redirect`.
- Amended `repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-layout.ftl` to render `<title>` tag using corresponding (channel) page title and fallback to document title if empty.
- Added title for page not found page.