### PR TITLE
NWPS-996: Configure allowed file extensions for "assetValidationService"

### DIFF
--- a/cms/src/main/resources/org/hippoecm/frontend/plugins/yui/upload/validation/DefaultUploadValidationService.properties
+++ b/cms/src/main/resources/org/hippoecm/frontend/plugins/yui/upload/validation/DefaultUploadValidationService.properties
@@ -1,0 +1,1 @@
+file.validation.extension.disallowed=The uploaded file ''{0}'' has extension {1} which is not allowed. Allowed extensions are: {2}. Please contact Service Desk on ''nwpsupport@hee.nhs.uk'' for more information.

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
@@ -3,4 +3,6 @@ definitions:
     /hippo:configuration/hippo:frontend/cms/cms-services/localeProviderService/en:
       country: gb
     /hippo:configuration/hippo:frontend/cms/cms-services/assetValidationService:
-      extensions.allowed: '*.pdf, *.doc, *.docx, *.ppt, *.pptx, *.xls, *.xlsx'
+      extensions.allowed: ['*.pdf', '*.doc', '*.docx', '*.ppt', '*.pptx', '*.xls',
+        '*.xlsx', '*.odt', '*.fodt', '*.odp', '*.fodp', '*.ods', '*.fods', '*.odg',
+        '*.fodg']

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
@@ -5,4 +5,6 @@ definitions:
     /hippo:configuration/hippo:frontend/cms/cms-services/assetValidationService:
       extensions.allowed: ['*.pdf', '*.doc', '*.docx', '*.ppt', '*.pptx', '*.xls',
         '*.xlsx', '*.odt', '*.fodt', '*.odp', '*.fodp', '*.ods', '*.fods', '*.odg',
-        '*.fodg']
+        '*.fodg', '*.mrc', '*.txt']
+    /hippo:configuration/hippo:frontend/cms/cms-services/imageValidationService:
+      extensions.allowed: ['*.jpg', '*.jpeg', '*.gif', '*.png']

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
@@ -2,3 +2,5 @@ definitions:
   config:
     /hippo:configuration/hippo:frontend/cms/cms-services/localeProviderService/en:
       country: gb
+    /hippo:configuration/hippo:frontend/cms/cms-services/assetValidationService:
+      extensions.allowed: '*.pdf, *.doc, *.docx, *.ppt, *.pptx, *.xls, *.xlsx'


### PR DESCRIPTION
- Including support for the following file extensions for Assets:
  - *.pdf
  - *.doc
  - *.docx
  - *.ppt
  - *.pptx
  - *.xls
  - *.xlsx
  - *.odt
  - *.fodt
  - *.odp
  - *.fodp
  - *.ods
  - *.fods
  - *.odg
  - *.fodg
  - *.mrc
  - *.txt
- Removed support for `SVG` for Images.
- Customised "file.validation.extension.disallowed" message (via `cms/src/main/resources/org/hippoecm/frontend/plugins/yui/upload/validation/DefaultUploadValidationService.properties`) to append the upload error msg with additional details requested by Andy.