### PR TITLE
NWPS-997: Removal of unsupported tags from CKEditor server-side whitelisting so as to filter them out.

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/htmlprocessor.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/htmlprocessor.yaml
@@ -16,5 +16,3 @@ definitions:
       .meta:delete: true
     /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/html:
       .meta:delete: true
-    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/img:
-      .meta:delete: true

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/htmlprocessor.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/htmlprocessor.yaml
@@ -2,3 +2,19 @@ definitions:
   config:
     /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/iframe:
       .meta:delete: true
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/embed:
+      .meta:delete: true
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/object:
+      .meta:delete: true
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/option:
+      .meta:delete: true
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/param:
+      .meta:delete: true
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/select:
+      .meta:delete: true
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/textarea:
+      .meta:delete: true
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/html:
+      .meta:delete: true
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/img:
+      .meta:delete: true

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/htmlprocessor.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/htmlprocessor.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext/iframe:
+      .meta:delete: true


### PR DESCRIPTION
Removed the following tags (and its attributes) from RichText editor server-side whitelisting config (`/hippo:configuration/hippo:modules/htmlprocessor/hippo:moduleconfig/richtext`) so as to filter them out:
- embed [allowscriptaccess, height, src, type, width]
- iframe [align, allow, allowfullscreen, class, frameborder, height, id, longdesc,
    name, scrolling, src, style, title, width]
- html
- object [align, class, data, height, id, style, title, type, width]
  - param [class, name, value, style]
- select [class, multiple, name, size, style]
  - option [class, selected, style, value]
- textarea [class, cols, name, rows, style]

`script` and `input` tags aren't whitelisted already and so no action is required. Thanks!