### PR TITLE
NWPS-1109: Disabling CKEditor automatic content filtering filter 

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hippostd/html.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hippostd/html.yaml
@@ -2,3 +2,4 @@ definitions:
   config:
     /hippo:namespaces/hippostd/html/editor:templates/_default_:
       ckeditor.config.appended.json: '{ removeButtons: "PickImage" }'
+      ckeditor.config.overlayed.json: '{ allowedContent: true }'


### PR DESCRIPTION
Disabling CKEditor automatic [Content Filtering](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_acf.html) feature as we have decided/implemented to go with [brXM HTML clean-up mechanism](https://xmdocumentation.bloomreach.com/library/concepts/document-types/html-fields/html-cleaning.html#scroll_server-side) as part of `NWPS-997` ticket to handle it at the server-side. Thanks!