### PR TITLE
NWPS-1125: Disabling blog comment feature

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/SuppressWasteMessageForBlogCommentContainerComponent.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/SuppressWasteMessageForBlogCommentContainerComponent.yaml
@@ -1,0 +1,26 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/SuppressWasteMessageForBlogCommentContainerComponent:
+      jcr:primaryType: hipposys:updaterinfo
+      hipposys:batchsize: 10
+      hipposys:description: Adds 'hst:suppresswastemessage = true' to all 'comment'
+        hst:containercomponent nodes in order to suppress logging comment component
+        waste message.
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:logtarget: REPOSITORY
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/hst:hee/hst:configurations/element(*, hst:configuration)/hst:workspace/hst:pages//element(comment,
+        hst:containercomponent)
+      hipposys:script: "package org.hippoecm.frontend.plugins.cms.admin.updater\r\n\
+        \r\nimport org.hippoecm.hst.configuration.HstNodeTypes\r\nimport org.onehippo.repository.update.BaseNodeUpdateVisitor\r\
+        \n\r\nimport javax.jcr.Node\r\n\r\nclass SuppressWasteMessageForBlogCommentContainerComponent\
+        \ extends BaseNodeUpdateVisitor {\r\n\r\n    boolean doUpdate(Node node) {\r\
+        \n        log.debug(\"Start updating comment [hst:containercomponent] node:\
+        \ '${node.getPath()}'\")\r\n        node.setProperty(HstNodeTypes.COMPONENT_PROPERTY_SUPPRESS_WASTE_MESSAGE,\
+        \ Boolean.TRUE)\r\n        log.debug(\"Successfully updated comment [hst:containercomponent]\
+        \ node '${node.getPath()}' \" +\r\n                \"with '${HstNodeTypes.COMPONENT_PROPERTY_SUPPRESS_WASTE_MESSAGE}=true'\
+        \ property\")\r\n\r\n        return true\r\n    }\r\n\r\n    boolean undoUpdate(Node\
+        \ node) {\r\n        throw new UnsupportedOperationException('Updater does\
+        \ not implement undoUpdate method')\r\n    }\r\n\r\n}"
+      hipposys:throttle: 1000

--- a/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/expert-searching-blog-page.yaml
+++ b/repository-data/site-development/src/main/resources/hcm-content/hst/configurations/lks/workspace/pages/expert-searching-blog-page.yaml
@@ -25,6 +25,7 @@
       hippo:identifier: 3009ef19-c5f6-4583-876b-e2f0d52941ee
       hst:label: Comment Form
       hst:lastmodified: 2021-05-05T09:19:22.498+07:00
+      hst:suppresswastemessage: true
       hst:xtype: hst.vbox
       /blog-comment-form:
         jcr:primaryType: hst:containeritemcomponent

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/prototypepages/blog-page.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/prototypepages/blog-page.yaml
@@ -14,6 +14,7 @@ definitions:
           hippo:identifier: 3009ef19-c5f6-4583-876b-e2f0d52941ee
           hst:label: Comment Form
           hst:xtype: hst.vbox
+          hst:suppresswastemessage: true
         /blog:
           jcr:primaryType: hst:containercomponent
           hippo:identifier: 9c5b2da6-9a3f-4964-8296-ac6af0793859

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/catalog.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/catalog.yaml
@@ -7,7 +7,7 @@ definitions:
       hst:parametervalues: [com.onehippo.cms7.eforms.hst.behaviors.AfterProcessBehavior]
     /hst:hst/hst:configurations/hst:default/hst:catalog/eforms-blog-catalog:
       jcr:primaryType: hst:containeritempackage
-      hst:hiddeninchannelmanager: false
+      hst:hiddeninchannelmanager: true
       /blog-comment-form:
         jcr:primaryType: hst:containeritemcomponent
         hst:componentclassname: uk.nhs.hee.web.components.eforms.NoAutoDetectFormComponent

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
@@ -135,7 +135,7 @@
         </div>
     </article>
 
-    <div class="nhsuk-grid-row">
+    <#--  <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
             <h2 data-anchorlinksignore="true">${totalComments} <@fmt.message key="comments"/></h2>
 
@@ -162,5 +162,5 @@
                 </#if>
             </#if>
         </div>
-    </div>
+    </div>  -->
 </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/blogpage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/pages/blogpage-main.ftl
@@ -12,10 +12,10 @@
     <main id="maincontent" role="main" class="nhsuk-main-wrapper">
         <@hst.include ref="blog"/>
 
-        <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
+        <#--  <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
             <div class="nhsuk-grid-column-two-thirds">
                 <@hst.include ref="comment"/>
             </div>
-        </div>
+        </div>  -->
     </main>
 </div>

--- a/site/components/src/main/java/uk/nhs/hee/web/components/BlogPostComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/BlogPostComponent.java
@@ -38,20 +38,9 @@ public class BlogPostComponent extends EssentialsDocumentComponent {
 
             addBlogListingPageURLToModel(request);
 
-            final List<BlogComment> comments = getModeratedComments(blogPost.getComments());
-            request.setModel("totalComments", comments.size());
-
-            if (comments.isEmpty()) {
-                return;
-            }
-
-            Collections.reverse(comments);
-            final boolean showAllComments = Boolean.parseBoolean(getPublicRequestParameter(request, "showAllComments"));
-            if (!showAllComments) {
-                request.setModel("visibleComments", comments.subList(0, Math.min(DEFAULT_NUMBER_OF_VISIBLE_COMMENTS, comments.size())));
-            } else {
-                request.setModel("visibleComments", comments);
-            }
+            // NWPS-1125: Commenting the following line in order to stop adding blog comments to the model
+            // as it isn't required to be displayed on 'site/freemarker/hee/catalog/blogpost-main.ftl' template.
+            // addBlogCommentsToModel(request, blogPost);
 
             request.setAttribute("tableComponentService", new TableComponentService());
         }
@@ -110,12 +99,29 @@ public class BlogPostComponent extends EssentialsDocumentComponent {
     private void addValueListsForContentBlocks(
             final HstRequest request,
             final BlogPost blogPost) {
-        List<HippoBean> pageContentBlocks = blogPost.getContentBlocks();
+        final List<HippoBean> pageContentBlocks = blogPost.getContentBlocks();
         pageContentBlocks.addAll(blogPost.getRightHandBlocks());
 
-        Map<String, Map<String, String>> modelToValueListMap =
+        final Map<String, Map<String, String>> modelToValueListMap =
                 ContentBlocksUtils.getValueListMaps(pageContentBlocks);
         modelToValueListMap.forEach(request::setModel);
+    }
+
+    private void addBlogCommentsToModel(final HstRequest request, final BlogPost blogPost) {
+        final List<BlogComment> comments = getModeratedComments(blogPost.getComments());
+        request.setModel("totalComments", comments.size());
+
+        if (comments.isEmpty()) {
+            return;
+        }
+
+        Collections.reverse(comments);
+        final boolean showAllComments = Boolean.parseBoolean(getPublicRequestParameter(request, "showAllComments"));
+        if (!showAllComments) {
+            request.setModel("visibleComments", comments.subList(0, Math.min(DEFAULT_NUMBER_OF_VISIBLE_COMMENTS, comments.size())));
+        } else {
+            request.setModel("visibleComments", comments);
+        }
     }
 
     /**


### PR DESCRIPTION
- Hides `Blog Comment Form` component from the Experience Manage component catalog so that Editor wouldn't be able to add it to the `Comment Form` container.
- Doesn't render blog comment form and existing comments on `Blog post` pages.
- `SuppressWasteMessageForBlogCommentContainerComponent` updater script which adds `hst:suppresswastemessage = true` property to all `comment` `hst:containercomponent` nodes in order to suppress logging `comment` component waste message [similar to the following]:

  ```[INFO] [talledLocalContainer] 29.09.2022 15:57:56 WARN  http-nio-8080-exec-6 [AggregationValve.logPossibleWaste:609] POSSIBLE WASTE DETECTED in request 'Request{ method='GET', scheme='http', host='localhost:8080', requestURI='/site/_cmsinternal/expert-searching', queryString='null'}' : Component '/hst:hee/hst:configurations/lks-preview/hst:workspace/hst:pages/expert-searching-blog-page/main/comment' gets rendered but never adds anything to the response. Its renderer 'classpath:vbox.ftl' is never flushed to a parent component. This might be waste you are not aware of. If it is on purpose, for example because the component does only some processing that does not involve direct response contribution, you can mark the component with 'hst:suppresswastemessage = true'.  ```
  
  Note that the SuppressWasteMessageForBlogCommentContainerComponent script needs to be run manually post-deployment.
Thanks!