### PR TITLE
NWPS-1089: Removal of 'description' field from 'Department' DocumentType

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/department.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/department.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 9a5a4af2-cb1d-46e6-a624-479aec9f5dc6
+          jcr:uuid: ff8dd828-aefd-48de-8be1-31b051d08c26
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -64,14 +64,6 @@ definitions:
             hipposysedit:path: hee:website
             hipposysedit:primary: false
             hipposysedit:type: String
-          /description:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: hee:description
-            hipposysedit:primary: false
-            hipposysedit:type: Text
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -87,12 +79,11 @@ definitions:
           hee:phoneNumber: ''
           hee:email: ''
           hee:address: ''
-          jcr:uuid: 92b2fa83-43a9-4cd6-a8cc-b2a3041655f8
+          jcr:uuid: cd4cff29-67ba-4f52-a657-27ba709c5046
           hippostdpubwf:lastModificationDate: 2021-05-13T16:54:57.592+07:00
           hippostdpubwf:creationDate: 2021-05-13T16:54:57.593+07:00
           hee:organisation: ''
           hee:website: ''
-          hee:description: ''
       /editor:templates:
         jcr:primaryType: editor:templateset
         /_default_:
@@ -149,15 +140,6 @@ definitions:
             jcr:primaryType: frontend:plugin
             caption: Address
             field: address
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /description:
-            jcr:primaryType: frontend:plugin
-            caption: Description
-            field: description
             hint: ''
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/department-contact.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/department-contact.ftl
@@ -35,10 +35,6 @@
             <#if department.address?has_content>
                 <p aria-label="Address">${department.address?replace('\n', '<br>')}</p>
             </#if>
-
-            <#if department.description?has_content>
-                <p class="nhsuk-u-secondary-text-color" aria-label="Description">${department.description}</p>
-            </#if>
         </div>
     </div>
 </#macro>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/Department.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/Department.java
@@ -35,9 +35,4 @@ public class Department extends BaseDocument {
     public String getWebsite() {
         return getSingleProperty("hee:website");
     }
-
-    @HippoEssentialsGenerated(internalName = "hee:description")
-    public String getDescription() {
-        return getSingleProperty("hee:description");
-    }
 }


### PR DESCRIPTION
- The existing Department `description` data from `repository-data/development` aren't removed yet as they would need to be migrated to the new `Contact card` DocumentType once it is created as part of `NWPS-1090`.
- Similarly, the logic for rendering Department `description` field has been removed from `repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/department-contact.ftl` and will be moved to freemarker template of `Contact card` that would be built as part of `NWPS-1090`.

Thanks!