### PR TITLE
NWPS-1184 - Remove Table Tool from toolbar

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/AfterForm.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/AfterForm.yaml
@@ -86,6 +86,7 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /backLink:
             jcr:primaryType: frontend:plugin
             caption: Back link

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
@@ -143,3 +143,4 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               showCompoundNames: 'true'
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/Inset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/Inset.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 47b38177-f672-42e7-9671-438e2c26528e
+          jcr:uuid: e78f4f56-fd5c-41ab-9552-41e7ea08ba37
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -35,7 +35,7 @@ definitions:
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: aea55bec-6732-4c33-835d-6ec49576439a
+          jcr:uuid: 8b5ce072-f678-4cf8-b5db-75d077cc344b
           hippostdpubwf:lastModificationDate: 2022-01-19T14:36:41.316Z
           hippostdpubwf:creationDate: 2022-01-19T14:36:41.316Z
           /hee:html:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/Inset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/Inset.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: e78f4f56-fd5c-41ab-9552-41e7ea08ba37
+          jcr:uuid: 47b38177-f672-42e7-9671-438e2c26528e
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -35,7 +35,7 @@ definitions:
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 8b5ce072-f678-4cf8-b5db-75d077cc344b
+          jcr:uuid: aea55bec-6732-4c33-835d-6ec49576439a
           hippostdpubwf:lastModificationDate: 2022-01-19T14:36:41.316Z
           hippostdpubwf:creationDate: 2022-01-19T14:36:41.316Z
           /hee:html:
@@ -61,3 +61,4 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/StatementBlock.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/StatementBlock.yaml
@@ -70,3 +70,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/banner.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/banner.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: a1573969-c7ca-477f-a7fd-a7cb4b09c4b9
+          jcr:uuid: 0e30dd7f-e52c-4d9e-a284-daf5e39f2c86
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -52,7 +52,7 @@ definitions:
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes: ['mix:referenceable']
           hee:tag: ''
-          jcr:uuid: 1f9a6380-cef8-4571-b0a0-b0f7dc4ea87c
+          jcr:uuid: 62dbba08-4721-44ac-bade-1a8df9e865aa
           hippostdpubwf:lastModificationDate: 2021-09-21T16:31:53.916+01:00
           hippostdpubwf:creationDate: 2021-09-21T16:31:53.916+01:00
           /hee:copy:
@@ -90,6 +90,7 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /copy1:
             jcr:primaryType: frontend:plugin
             caption: Bottom Copy
@@ -99,3 +100,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/banner.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/banner.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 0e30dd7f-e52c-4d9e-a284-daf5e39f2c86
+          jcr:uuid: a1573969-c7ca-477f-a7fd-a7cb4b09c4b9
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -52,7 +52,7 @@ definitions:
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes: ['mix:referenceable']
           hee:tag: ''
-          jcr:uuid: 62dbba08-4721-44ac-bade-1a8df9e865aa
+          jcr:uuid: 1f9a6380-cef8-4571-b0a0-b0f7dc4ea87c
           hippostdpubwf:lastModificationDate: 2021-09-21T16:31:53.916+01:00
           hippostdpubwf:creationDate: 2021-09-21T16:31:53.916+01:00
           /hee:copy:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blockLinks.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blockLinks.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype[1]:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['hipposysedit:remodel', 'mix:referenceable']
-          jcr:uuid: 9d020927-5d62-4522-9ca5-da88d9583560
+          jcr:uuid: 517fca08-292b-4c7d-866e-72b525c8c7cb
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -53,7 +53,7 @@ definitions:
         /hipposysedit:prototype[1]:
           jcr:primaryType: hee:blockLinks
           jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 4cacd851-146e-4c23-8fab-b3f1597e510e
+          jcr:uuid: 640ac864-8de9-4cb5-bb2b-06bc340bbd08
           hee:title: ''
           hippostd:holder: holder
           hippostd:state: draft
@@ -102,6 +102,7 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /blockLinks:
             jcr:primaryType: frontend:plugin
             caption: Block links

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blockLinks.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blockLinks.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype[1]:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['hipposysedit:remodel', 'mix:referenceable']
-          jcr:uuid: 517fca08-292b-4c7d-866e-72b525c8c7cb
+          jcr:uuid: 9d020927-5d62-4522-9ca5-da88d9583560
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -53,7 +53,7 @@ definitions:
         /hipposysedit:prototype[1]:
           jcr:primaryType: hee:blockLinks
           jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 640ac864-8de9-4cb5-bb2b-06bc340bbd08
+          jcr:uuid: 4cacd851-146e-4c23-8fab-b3f1597e510e
           hee:title: ''
           hippostd:holder: holder
           hippostd:state: draft

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
@@ -255,6 +255,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               showCompoundNames: 'true'
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /rightHandBlocks:
             jcr:primaryType: frontend:plugin
             caption: Right hand objects
@@ -266,6 +267,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               showCompoundNames: 'true'
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /pageLastNextReview:
             jcr:primaryType: frontend:plugin
             caption: Page review dates

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
@@ -206,6 +206,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               showCompoundNames: 'true'
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /rightHandBlocks:
             jcr:primaryType: frontend:plugin
             caption: Right hand objects
@@ -218,6 +219,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               showCompoundNames: 'true'
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /pageLastNextReview:
             jcr:primaryType: frontend:plugin
             caption: Page review dates

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/landingPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/landingPage.yaml
@@ -151,6 +151,7 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /addToAZ:
             jcr:primaryType: frontend:plugin
             caption: Add to A to Z

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/mediaEmbed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/mediaEmbed.yaml
@@ -166,6 +166,7 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /mediaLastNextReview:
             jcr:primaryType: frontend:plugin
             caption: Media review dates

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/navMap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/navMap.yaml
@@ -117,6 +117,7 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /mapEducation:
             jcr:primaryType: frontend:plugin
             caption: Map Education

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
@@ -235,6 +235,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               showCompoundNames: 'true'
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /categories:
             jcr:primaryType: frontend:plugin
             caption: Categories
@@ -263,6 +264,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               showCompoundNames: 'true'
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /pageLastNextReview:
             jcr:primaryType: frontend:plugin
             caption: Page review dates

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/newsletterSubscribeForm.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/newsletterSubscribeForm.yaml
@@ -193,6 +193,7 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /successUrl:
             jcr:primaryType: frontend:plugin
             caption: Success url

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/report.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/report.yaml
@@ -235,6 +235,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               showCompoundNames: 'true'
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'
           /pageLastNextReview:
             jcr:primaryType: frontend:plugin
             caption: Page review dates

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/richTextBlock.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/richTextBlock.yaml
@@ -61,3 +61,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/statementCard.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/statementCard.yaml
@@ -79,3 +79,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/warningCallout.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/warningCallout.yaml
@@ -79,3 +79,4 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "Table"}'

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/case-studies.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/case-studies.yaml
@@ -31,9 +31,9 @@
         hee:submittedDate: 2022-04-07T00:00:00+01:00
         hee:title: Modern apprentice in cellular pathology
         hippo:availability: []
-        hippostd:holder: admin
         hippostd:retainable: false
         hippostd:state: draft
+        hippostd:transferable: false
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-07T20:14:52.104+01:00
         hippostdpubwf:lastModificationDate: 2022-09-25T16:43:20.723+01:00
@@ -135,9 +135,9 @@
       hee:submittedDate: 0001-01-01T12:00:00Z
       hee:title: 'Search: Case Study'
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-07-21T07:31:06.473+01:00
       hippostdpubwf:lastModificationDate: 2022-09-25T16:38:21.808+01:00
@@ -230,9 +230,9 @@
       hee:submittedDate: 2022-04-08T00:00:00+01:00
       hee:title: Test Title
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2022-02-14T16:08:16.437Z
       hippostdpubwf:lastModificationDate: 2022-09-25T16:39:06.656+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/landing-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/landing-pages.yaml
@@ -21,9 +21,9 @@
       hee:summary: Get the latest information and advice on LKS
       hee:title: Knowledge management
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-05T11:06:13.862+07:00
       hippostdpubwf:lastModificationDate: 2022-08-10T14:27:27.349+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/reports.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/reports.yaml
@@ -391,9 +391,9 @@
       hee:summary: Demo about Publication Page is working with the new requirements.
       hee:title: Publication
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2022-10-07T10:22:48.555+01:00
       hippostdpubwf:lastModificationDate: 2022-10-09T12:15:56.584+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/search-bank.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/search-bank.yaml
@@ -139,9 +139,9 @@
       hee:title: 'Search: Search Bank'
       hee:topics: [testing]
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-07-21T06:49:46.314+01:00
       hippostdpubwf:lastModificationDate: 2022-02-14T18:23:42.609Z


### PR DESCRIPTION
Please review it

Removed table tool option for the following content types

1. After Form ( Enterprise Forms)
2. Banner
3. Block Links
4. Inset
5. Media Embed
6. Navigation Map
7. Newsletter Subscribe Form
8. Rich Text Box - Reusable
9. Statement Card
10. Statement Block
11. Warning Callout
12. Home Page  - Rich Text Box - Single Use
13. Standard Content Page - Rich Text Box - Single Use
14. Landing Page - Rich Text Box - Single Use
15. Blog Post - Rich Text Box - Single Use
16. News - Rich Text Box - Single Use
17. Publication - Rich Text Box - Single Use