### PR TITLE
NWPS-1003: Moving 'multi-org-logo' container specific CSS classes onto 'cms-request.css' for consistency

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/css/cms-request.css
+++ b/repository-data/webfiles/src/main/resources/site/css/cms-request.css
@@ -23,3 +23,7 @@
   width: 40px;
   height: 40px;
 }
+
+.nhsuk-header__multilogo .hst-container {
+  width:100%
+}

--- a/repository-data/webfiles/src/main/resources/site/css/hee_custom_backend.css
+++ b/repository-data/webfiles/src/main/resources/site/css/hee_custom_backend.css
@@ -1,3 +1,0 @@
-.nhsuk-header__multilogo .hst-container {
-    width:100%
-}

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-layout.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-layout.ftl
@@ -16,7 +16,6 @@
     <!-- Styles -->
     <link rel="stylesheet" href="<@hst.webfile path='/css/nhsuk-4.1.min.css'/>" type="text/css"/>
     <link rel="stylesheet" href="<@hst.webfile path='/css/hee.min.css'/>" type="text/css"/>
-    <link rel="stylesheet" href="<@hst.webfile path='/css/hee_custom_backend.css'/>" type="text/css"/>
     <#if hstRequest.requestContext.channelManagerPreviewRequest>
       <link rel="stylesheet" href="<@hst.webfile  path="/css/cms-request.css"/>" type="text/css"/>
     </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
@@ -24,7 +24,11 @@
         <#--  Multi-org logos: START  -->
         <@hst.include ref="multi-org-logo" var="multiOrgLogoHTML"/>
         <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->
-        ${multiOrgLogoHTML}
+        <#if hstRequest.requestContext.channelManagerPreviewRequest>
+            ${multiOrgLogoHTML}
+        <#else>
+            ${multiOrgLogoHTML!?replace('<div>', '')?replace('</div>', '')}
+        </#if>
         <#--  Multi-org logos: END  -->
     </div>
     <#--  Logo and org name & descriptor: END  -->

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
@@ -23,12 +23,8 @@
 
         <#--  Multi-org logos: START  -->
         <@hst.include ref="multi-org-logo" var="multiOrgLogoHTML"/>
-        <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->
-        <#if hstRequest.requestContext.channelManagerPreviewRequest>
-            ${multiOrgLogoHTML}
-        <#else>
-            ${multiOrgLogoHTML!?replace('<div>', '')?replace('</div>', '')}
-        </#if>
+        <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->       
+            ${multiOrgLogoHTML}       
         <#--  Multi-org logos: END  -->
     </div>
     <#--  Logo and org name & descriptor: END  -->

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
@@ -23,7 +23,7 @@
 
         <#--  Multi-org logos: START  -->
         <@hst.include ref="multi-org-logo" var="multiOrgLogoHTML"/>
-        <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->       
+        <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->     
         ${multiOrgLogoHTML}
         <#--  Multi-org logos: END  -->
     </div>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
@@ -24,7 +24,7 @@
         <#--  Multi-org logos: START  -->
         <@hst.include ref="multi-org-logo" var="multiOrgLogoHTML"/>
         <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->       
-        ${multiOrgLogoHTML}  
+        ${multiOrgLogoHTML}
         <#--  Multi-org logos: END  -->
     </div>
     <#--  Logo and org name & descriptor: END  -->

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
@@ -24,7 +24,7 @@
         <#--  Multi-org logos: START  -->
         <@hst.include ref="multi-org-logo" var="multiOrgLogoHTML"/>
         <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->       
-            ${multiOrgLogoHTML}       
+        ${multiOrgLogoHTML}  
         <#--  Multi-org logos: END  -->
     </div>
     <#--  Logo and org name & descriptor: END  -->

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/layout/base-top.ftl
@@ -23,7 +23,7 @@
 
         <#--  Multi-org logos: START  -->
         <@hst.include ref="multi-org-logo" var="multiOrgLogoHTML"/>
-        <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->     
+        <#--  Workaround to remove additional wrapper div's introduced by 'multi-org-logo' container  -->
         ${multiOrgLogoHTML}
         <#--  Multi-org logos: END  -->
     </div>


### PR DESCRIPTION
Also, added a workaround to remove additional wrapper div's introduced by 'multi-org-logo' container for non channel manager preview requests.