### PR TITLE
NWPS-902: 'Details (reusable)' link picker document type restriction

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/detailsReference.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/detailsReference.yaml
@@ -51,3 +51,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              nodetypes: ['hee:details']


### PR DESCRIPTION
`Details (reusable)` link picker update to restrict it to accept only `hee:details` document type