### PR TITLE
NWPS-1184: Removal of 'Table' button from RTE globally except Details, Expander, Table & Tabs document types

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/details.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/details.yaml
@@ -79,3 +79,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "PickImage" }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/expanderPanel.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/expanderPanel.yaml
@@ -69,3 +69,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.appended.json: '{ removeButtons: "PickImage" }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hippostd/html.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hippostd/html.yaml
@@ -1,5 +1,5 @@
 definitions:
   config:
     /hippo:namespaces/hippostd/html/editor:templates/_default_:
-      ckeditor.config.appended.json: '{ removeButtons: "PickImage" }'
+      ckeditor.config.appended.json: '{ removeButtons: "PickImage,Table" }'
       ckeditor.config.overlayed.json: '{ allowedContent: true }'

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/case-studies.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/case-studies.yaml
@@ -31,9 +31,9 @@
         hee:submittedDate: 2022-04-07T00:00:00+01:00
         hee:title: Modern apprentice in cellular pathology
         hippo:availability: []
-        hippostd:holder: admin
         hippostd:retainable: false
         hippostd:state: draft
+        hippostd:transferable: false
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-07T20:14:52.104+01:00
         hippostdpubwf:lastModificationDate: 2022-09-25T16:43:20.723+01:00
@@ -135,9 +135,9 @@
       hee:submittedDate: 0001-01-01T12:00:00Z
       hee:title: 'Search: Case Study'
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-07-21T07:31:06.473+01:00
       hippostdpubwf:lastModificationDate: 2022-09-25T16:38:21.808+01:00
@@ -230,9 +230,9 @@
       hee:submittedDate: 2022-04-08T00:00:00+01:00
       hee:title: Test Title
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2022-02-14T16:08:16.437Z
       hippostdpubwf:lastModificationDate: 2022-09-25T16:39:06.656+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/landing-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/landing-pages.yaml
@@ -21,9 +21,9 @@
       hee:summary: Get the latest information and advice on LKS
       hee:title: Knowledge management
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-05T11:06:13.862+07:00
       hippostdpubwf:lastModificationDate: 2022-08-10T14:27:27.349+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/reports.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/reports.yaml
@@ -391,9 +391,9 @@
       hee:summary: Demo about Publication Page is working with the new requirements.
       hee:title: Publication
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2022-10-07T10:22:48.555+01:00
       hippostdpubwf:lastModificationDate: 2022-10-09T12:15:56.584+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/search-bank.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/search-bank.yaml
@@ -139,9 +139,9 @@
       hee:title: 'Search: Search Bank'
       hee:topics: [testing]
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:transferable: false
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-07-21T06:49:46.314+01:00
       hippostdpubwf:lastModificationDate: 2022-02-14T18:23:42.609Z


### PR DESCRIPTION
Includes cherry-picked a8f1f968dbd6188c58873002cf7d603a34ad90a9 commit as well (to close opened documents).

We can close https://github.com/Health-Education-England/hee-cms-platform/pull/285 if we are happy with this.