### PR TITLE
NWPS-1275: Department field & validation update

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/department.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/department.yaml
@@ -15,7 +15,6 @@ definitions:
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
-          hipposysedit:validators: ['hee:mandatory-contact-validator']
           /name:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -42,7 +41,7 @@ definitions:
             hipposysedit:path: hee:email
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators: ['hee:optional-email-validator']
+            hipposysedit:validators: [email, required]
           /address:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false


### PR DESCRIPTION
- Reverting `email` field as mandatory for `Department` document type.
- Reverting mandatory contact validation from `Department` document type.