### PR TITLE
NWPS-1088 & NWPS-1089: Latest person/department updates

### DIFF
--- a/cms/src/main/java/uk/nhs/hee/web/validation/validator/PhoneNumberValidator.java
+++ b/cms/src/main/java/uk/nhs/hee/web/validation/validator/PhoneNumberValidator.java
@@ -1,6 +1,5 @@
 package uk.nhs.hee.web.validation.validator;
 
-import com.google.common.base.CharMatcher;
 import org.apache.commons.lang3.StringUtils;
 import org.onehippo.cms.services.validation.api.ValidationContext;
 import org.onehippo.cms.services.validation.api.Validator;
@@ -19,14 +18,9 @@ public class PhoneNumberValidator implements Validator<String> {
     // Logger
     private static final Logger LOGGER = LoggerFactory.getLogger(PhoneNumberValidator.class);
 
-    // CharMatcher instance of common multiple phone number separators
-    private static final CharMatcher MULTIPLE_PHONE_NUMBER_SEPARATOR_CHAR_MATCHER = CharMatcher.anyOf("/\\|,;:");
-
     // UK country code
     private static final String UK_COUNTRY_CODE = "+44";
 
-    // Phone number extension keyword
-    private static final String PHONE_NUMBER_EXTENSION_KEYWORD = "ext";
 
     /**
      * Returns an {@link Optional<Violation>} instance in case of validation violation.
@@ -45,36 +39,24 @@ public class PhoneNumberValidator implements Validator<String> {
             return Optional.empty();
         }
 
-        // Validates the existence of UK country code (+44) prefix in the given phone number.
-        if (!hasUKCountryCode(value)) {
-            LOGGER.debug("The phone number '{}' doesn't have UK country code ({}) and " +
-                    "please prefix it with one", value, UK_COUNTRY_CODE);
-            return Optional.of(context.createViolation("no-uk-country-code-error"));
+        // Validates if the given phone number hasn't been prefixed with UK country code (+44).
+        if (hasUKCountryCode(value)) {
+            LOGGER.debug("The phone number '{}' has been prefixed with UK country code ({}). " +
+                    "Please remove it.", value, UK_COUNTRY_CODE);
+            return Optional.of(context.createViolation("uk-country-code-error"));
         }
 
-        // Validates if the given phone number has multiple contact numbers in it.
-        if (hasMultiplePhoneNumbers(value)) {
-            LOGGER.debug("The phone number '{}' has common contact number separators " +
-                            "(forward slash [/], backward slash [\\], comma [,] and pipe [|]) " +
-                            "and is likely to contain multiple contact numbers. " +
-                            "Please enter one contact number only",
-                    value);
-            return Optional.of(context.createViolation("multiple-contact-numbers-error"));
-        }
-
-        // Validates if the given phone number has extension included in it.
-        if (hasExtension(value)) {
-            LOGGER.debug("The phone number '{}' has '{}' keyword " +
-                            "and is likely to contain extension in it. Please remove the extension if any.",
-                    value, PHONE_NUMBER_EXTENSION_KEYWORD);
-            return Optional.of(context.createViolation("phone-number-extension-input-suggestion"));
-        }
-
-        // Validates if the given phone number has minimum 13 digits
-        // UK Access Code (+44) = 3 digits + 10 digits ( for uk phone numbers) = 13
-        if (value.length() >0  && value.length() < 13) {
-            LOGGER.debug("The phone number '{}' should contain minimum 13 digits ",value);
-            return Optional.of(context.createViolation("phone-number-minimum-digits-input-suggestion"));
+        final String phoneNumberWithoutSpaces = StringUtils.deleteWhitespace(value);
+        // Validates if the given phone number has only numeric/space characters
+        // and contains at least 10 digits (excluding trunk[0]/country code[44] prefixes).
+        if (!StringUtils.isNumericSpace(value) ||
+                phoneNumberWithoutSpaces.length() < 10 ||
+                (phoneNumberWithoutSpaces.startsWith("0") && phoneNumberWithoutSpaces.length() != 11) ||
+                (phoneNumberWithoutSpaces.startsWith("44") && phoneNumberWithoutSpaces.length() != 12)) {
+            LOGGER.debug("The phone number '{}' contains either non numeric/space characters " +
+                    "or less than 10 digits (excluding trunk[0]/country code[44] prefixes). " +
+                    "Please enter a valid phone number", value);
+            return Optional.of(context.createViolation("invalid-phone-number"));
         }
 
         return Optional.empty();
@@ -90,38 +72,5 @@ public class PhoneNumberValidator implements Validator<String> {
      */
     private boolean hasUKCountryCode(final String phoneNumber) {
         return phoneNumber.startsWith(UK_COUNTRY_CODE);
-    }
-
-    /**
-     * Returns {@code true} if the given {@code phoneNumber} contains common phone number separator characters.
-     * Otherwise, returns {@code false}.
-     *
-     * <p>It currently checks for the following characters in the given {@code phoneNumber}
-     * in order to check the existence of multiple phone numbers:</p>
-     * <ul>
-     *     <li>forward slash (/)</li>
-     *     <li>backward slash (\)</li>
-     *     <li>comma (,)</li>
-     *     <li>pipe (|)</li>
-     * </ul>
-     *
-     * @param phoneNumber the phone number.
-     * @return {@code true} if the given {@code phoneNumber} contains common phone number separator characters.
-     * Otherwise, returns {@code false}.
-     */
-    private boolean hasMultiplePhoneNumbers(final String phoneNumber) {
-        return MULTIPLE_PHONE_NUMBER_SEPARATOR_CHAR_MATCHER.matchesAnyOf(phoneNumber);
-    }
-
-    /**
-     * Returns {@code true} if the given {@code phoneNumber} has {@code ext} substring.
-     * Otherwise, returns {@code false}.
-     *
-     * @param phoneNumber the phone number.
-     * @return {@code true} if the given {@code phoneNumber} has {@code ext} substring.
-     * Otherwise, returns {@code false}.
-     */
-    private boolean hasExtension(final String phoneNumber) {
-        return phoneNumber.toLowerCase().contains(PHONE_NUMBER_EXTENSION_KEYWORD);
     }
 }

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
@@ -11,17 +11,14 @@ definitions:
         sure to add all its (regional) Links.
       hee:link-validator: Please enter either Link Document or URL.
       hee:applies-to-country-validator: Enter the Link URL.
-      hee:phone-number-validator#phone-number-extension-input-suggestion: Please move
-        the extension to 'Phone extension' field
-      hee:phone-number-validator#no-uk-country-code-error: Please prefix the phone
-        number with UK country code '+44'
-      hee:phone-number-validator#multiple-contact-numbers-error: Please enter one
-        contact number only
-      hee:phone-number-validator#phone-number-minimum-digits-input-suggestion: Please
-        enter valid phone number - minimum 10 digits
       hee:optional-url-validator: Enter a valid URL
       hee:mandatory-contact-validator: Please enter Phone number and/or Email
       hee:optional-email-validator: Enter a valid email address
-      hee:numeric-validator: Please enter a valid number
+      hee:numeric-validator: Please enter a number
       hee:mandatory-publication-professions-or-topics-validator: Please select at
         least one option from either Professions or Topics
+      hee:phone-number-validator#uk-country-code-error: Please remove UK country code
+        prefix '+44' from the phone number
+      hee:phone-number-validator#invalid-phone-number: Please enter a valid phone
+        number containing 10 digits (excluding trunk[0]/country code[44] prefixes)
+        (e.g. 123 456 7891)

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/RemoveUKCountryCodeFromPhoneNumbers.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/registry/RemoveUKCountryCodeFromPhoneNumbers.yaml
@@ -1,0 +1,31 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/RemoveUKCountryCodeFromPhoneNumbers:
+      jcr:primaryType: hipposys:updaterinfo
+      hipposys:batchsize: 10
+      hipposys:description: Removes UK country code (+44) prefixes from Person/Department
+        phone numbers
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:logtarget: REPOSITORY
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/content/documents//*[(@jcr:primaryType='hee:person'
+        or @jcr:primaryType='hee:department') and @hee:phoneNumber!='']
+      hipposys:script: "package org.hippoecm.frontend.plugins.cms.admin.updater\r\n\
+        \r\n\r\nimport org.onehippo.repository.update.BaseNodeUpdateVisitor\r\n\r\n\
+        import javax.jcr.Node\r\n\r\nclass RemoveUKCountryCodeFromPhoneNumbers extends\
+        \ BaseNodeUpdateVisitor {\r\n\r\n    boolean doUpdate(Node node) {\r\n   \
+        \     log.debug \"Updating node ${node.path}\"\r\n\r\n        final String\
+        \ phoneNumber = node.getProperty(\"hee:phoneNumber\").getString()\r\n    \
+        \    log.debug \"Phone number [Before reformatting] = ${phoneNumber}\"\r\n\
+        \r\n        // Replaces '+44 '/'+44' with empty string\r\n        // i.e.\
+        \ essentially removes UK country code prefix (+44) from the phone number\r\
+        \n        final String reformattedPhoneNumber = phoneNumber.replaceAll(\"\\\
+        \\+44\\\\s?(.*)\", \"\\$1\")\r\n        log.debug \"Phone number [After reformatting]\
+        \ = ${reformattedPhoneNumber}\"\r\n\r\n        node.setProperty(\"hee:phoneNumber\"\
+        , reformattedPhoneNumber)\r\n\r\n        log.debug \"Successfully migrated/replaced\
+        \ '${node.path}' phone number from '${phoneNumber}' \" +\r\n             \
+        \   \"to '${reformattedPhoneNumber}'\"\r\n        return true\r\n    }\r\n\
+        \r\n    boolean undoUpdate(Node node) {\r\n        throw new UnsupportedOperationException('Updater\
+        \ does not implement undoUpdate method')\r\n    }\r\n\r\n}"
+      hipposys:throttle: 1000

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/department.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/department.yaml
@@ -84,6 +84,7 @@ definitions:
             hipposysedit:path: hee:phoneExtension
             hipposysedit:primary: false
             hipposysedit:type: String
+            hipposysedit:validators: ['hee:numeric-validator']
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -142,10 +143,11 @@ definitions:
             field: phoneNumber
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-            hint: Enter the primary contact number for the department e.g. +44 12345
-              1234
+            hint: Enter the primary contact number for the department e.g. 123 456
+              7891
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              maxlength: '13'
           /phoneExtension:
             jcr:primaryType: frontend:plugin
             caption: Phone extension
@@ -155,6 +157,7 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              maxlength: '5'
           /email:
             jcr:primaryType: frontend:plugin
             caption: Email
@@ -184,10 +187,11 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
           /description:
             jcr:primaryType: frontend:plugin
-            caption: Description
+            caption: Description (This field is being removed)
             field: description
             hint: ''
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+            mode: view
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/person.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/person.yaml
@@ -141,6 +141,7 @@ definitions:
             hipposysedit:path: hee:phoneExtension
             hipposysedit:primary: false
             hipposysedit:type: String
+            hipposysedit:validators: ['hee:numeric-validator']
           /department:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -268,9 +269,10 @@ definitions:
             field: phoneNumber
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-            hint: e.g. +44 12345 1234
+            hint: e.g. 123 456 7891
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              maxlength: '13'
           /phoneExtension:
             jcr:primaryType: frontend:plugin
             caption: Phone extension
@@ -280,6 +282,7 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              maxlength: '5'
           /email:
             jcr:primaryType: frontend:plugin
             caption: Email

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/person.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/person.yaml
@@ -141,6 +141,14 @@ definitions:
             hipposysedit:path: hee:phoneExtension
             hipposysedit:primary: false
             hipposysedit:type: String
+          /department:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:department
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:mirror
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -175,6 +183,9 @@ definitions:
             hippo:facets: []
             hippo:modes: []
             hippo:values: []
+          /hee:department:
+            jcr:primaryType: hippo:mirror
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
       /editor:templates:
         jcr:primaryType: editor:templateset
         /_default_:
@@ -225,12 +236,23 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
           /departmentName:
             jcr:primaryType: frontend:plugin
-            caption: Department name
+            caption: Department name (This field is being removed)
             field: departmentName
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+            mode: view
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+          /department:
+            jcr:primaryType: frontend:plugin
+            caption: Department
+            field: department
+            hint: Browse to a department document
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              nodetypes: ['hee:department']
           /organisation:
             jcr:primaryType: frontend:plugin
             caption: Organisation
@@ -314,11 +336,12 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
           /bio:
             jcr:primaryType: frontend:plugin
-            caption: Bio
+            caption: Bio (This field is being removed)
             field: bio
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
             hint: ''
+            mode: view
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               maxlength: ''

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
@@ -1799,7 +1799,7 @@
       jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
       jcr:uuid: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
       hippo:name: James Smith
-      hippo:versionHistory: 5941f13c-d0d8-464f-8534-f74af63b7a13
+      hippo:versionHistory: 39c67ef2-8a7f-4c93-acf8-3bca419eca9b
       /james-smith[1]:
         jcr:primaryType: hee:person
         jcr:mixinTypes: ['mix:referenceable']
@@ -1817,18 +1817,18 @@
         hee:linkedIn: ''
         hee:name: James Smith
         hee:organisation: ''
-        hee:phoneExtension: ''
-        hee:phoneNumber: +44 733 910 013
+        hee:phoneExtension: '1234'
+        hee:phoneNumber: 44 1482857190
         hee:pronouns: he/him
         hee:title: Mr
         hee:twitter: itsleepeart
+        hee:website: ''
         hippo:availability: []
         hippostd:retainable: false
         hippostd:state: draft
-        hippostd:transferable: false
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-13T16:59:45.575+07:00
-        hippostdpubwf:lastModificationDate: 2022-11-02T16:51:42.233Z
+        hippostdpubwf:lastModificationDate: 2022-12-22T13:04:22.485Z
         hippostdpubwf:lastModifiedBy: admin
         hippotranslation:id: 423fafcb-edd2-415a-b464-ba34af1fe3f1
         hippotranslation:locale: en
@@ -1858,17 +1858,18 @@
         hee:linkedIn: ''
         hee:name: James Smith
         hee:organisation: ''
-        hee:phoneExtension: ''
-        hee:phoneNumber: +44 733 910 013
+        hee:phoneExtension: '1234'
+        hee:phoneNumber: 44 1482857190
         hee:pronouns: he/him
         hee:title: Mr
         hee:twitter: itsleepeart
+        hee:website: ''
         hippo:availability: [preview]
         hippostd:retainable: false
         hippostd:state: unpublished
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-13T16:59:45.575+07:00
-        hippostdpubwf:lastModificationDate: 2022-11-02T16:51:54.364Z
+        hippostdpubwf:lastModificationDate: 2022-12-22T13:04:41.573Z
         hippostdpubwf:lastModifiedBy: admin
         hippotranslation:id: 423fafcb-edd2-415a-b464-ba34af1fe3f1
         hippotranslation:locale: en
@@ -1898,19 +1899,20 @@
         hee:linkedIn: ''
         hee:name: James Smith
         hee:organisation: ''
-        hee:phoneExtension: ''
-        hee:phoneNumber: +44 733 910 013
+        hee:phoneExtension: '1234'
+        hee:phoneNumber: 44 1482857190
         hee:pronouns: he/him
         hee:title: Mr
         hee:twitter: itsleepeart
+        hee:website: ''
         hippo:availability: [live]
         hippostd:retainable: false
         hippostd:state: published
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-13T16:59:45.575+07:00
-        hippostdpubwf:lastModificationDate: 2022-11-02T16:51:54.364Z
+        hippostdpubwf:lastModificationDate: 2022-12-22T13:04:41.573Z
         hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2022-11-02T16:51:56.198Z
+        hippostdpubwf:publicationDate: 2022-12-22T13:04:43.649Z
         hippotranslation:id: 423fafcb-edd2-415a-b464-ba34af1fe3f1
         hippotranslation:locale: en
         /hee:image:
@@ -1927,7 +1929,7 @@
       jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
       jcr:uuid: 8abb6cfe-b38d-4de5-8948-6bc9d1e6b973
       hippo:name: John Doe
-      hippo:versionHistory: 1da3cf40-07bd-4f7a-b124-9d0d05084bf8
+      hippo:versionHistory: 2de24cf0-aa46-4649-9433-e40fab272962
       /john-doe[1]:
         jcr:primaryType: hee:person
         jcr:mixinTypes: ['mix:referenceable']
@@ -1941,11 +1943,11 @@
         hee:email: john.doe@hee.co.uk
         hee:jobTitle: Head of Department
         hee:linkUrl: http://mypage
-        hee:linkedIn: john-doe
+        hee:linkedIn: john-doeds
         hee:name: John Doe
         hee:organisation: HEE Dental Organisation
-        hee:phoneExtension: '1234'
-        hee:phoneNumber: +44 1234 567890
+        hee:phoneExtension: ''
+        hee:phoneNumber: 20 3456 1114
         hee:pronouns: he/him
         hee:title: Prof
         hee:twitter: mypage
@@ -1955,7 +1957,7 @@
         hippostd:state: draft
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-20T20:20:28.038+01:00
-        hippostdpubwf:lastModificationDate: 2022-12-06T21:03:43.934Z
+        hippostdpubwf:lastModificationDate: 2022-12-22T13:04:54.405Z
         hippostdpubwf:lastModifiedBy: admin
         hippotranslation:id: a994448f-582f-4073-913b-a3372cd5740b
         hippotranslation:locale: en
@@ -1981,11 +1983,11 @@
         hee:email: john.doe@hee.co.uk
         hee:jobTitle: Head of Department
         hee:linkUrl: http://mypage
-        hee:linkedIn: john-doe
+        hee:linkedIn: john-doeds
         hee:name: John Doe
         hee:organisation: HEE Dental Organisation
-        hee:phoneExtension: '1234'
-        hee:phoneNumber: +44 1234 567890
+        hee:phoneExtension: ''
+        hee:phoneNumber: 20 3456 1114
         hee:pronouns: he/him
         hee:title: Prof
         hee:twitter: mypage
@@ -1995,7 +1997,7 @@
         hippostd:state: unpublished
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-20T20:20:28.038+01:00
-        hippostdpubwf:lastModificationDate: 2022-12-06T21:03:48.385Z
+        hippostdpubwf:lastModificationDate: 2022-12-21T19:36:55.833Z
         hippostdpubwf:lastModifiedBy: admin
         hippotranslation:id: a994448f-582f-4073-913b-a3372cd5740b
         hippotranslation:locale: en
@@ -2021,11 +2023,11 @@
         hee:email: john.doe@hee.co.uk
         hee:jobTitle: Head of Department
         hee:linkUrl: http://mypage
-        hee:linkedIn: john-doe
+        hee:linkedIn: john-doeds
         hee:name: John Doe
         hee:organisation: HEE Dental Organisation
-        hee:phoneExtension: '1234'
-        hee:phoneNumber: +44 1234 567890
+        hee:phoneExtension: ''
+        hee:phoneNumber: 20 3456 1114
         hee:pronouns: he/him
         hee:title: Prof
         hee:twitter: mypage
@@ -2035,9 +2037,9 @@
         hippostd:state: published
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-20T20:20:28.038+01:00
-        hippostdpubwf:lastModificationDate: 2022-12-06T21:03:48.385Z
+        hippostdpubwf:lastModificationDate: 2022-12-21T19:36:55.833Z
         hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2022-12-06T21:03:50.043Z
+        hippostdpubwf:publicationDate: 2022-12-22T12:45:48.140Z
         hippotranslation:id: a994448f-582f-4073-913b-a3372cd5740b
         hippotranslation:locale: en
         /hee:image:
@@ -2062,7 +2064,7 @@
       jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
       jcr:uuid: 0e3ac71e-c72b-4868-9eb6-a38fdfcebc7f
       hippo:name: Development
-      hippo:versionHistory: affc49b7-59f3-416c-b643-a04be5667717
+      hippo:versionHistory: ecf4fa96-954c-42f6-9bad-86b530cba972
       /development[1]:
         jcr:primaryType: hee:department
         jcr:mixinTypes: ['mix:referenceable']
@@ -2073,14 +2075,15 @@
         hee:email: development@gmail.com
         hee:name: Development
         hee:organisation: HEE Development Organisation
-        hee:phoneNumber: +44 7575 731 776
+        hee:phoneExtension: ''
+        hee:phoneNumber: 0113 887 1725
         hee:website: http://hee.development.org
         hippo:availability: []
         hippostd:retainable: false
         hippostd:state: draft
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-13T17:02:14.997+07:00
-        hippostdpubwf:lastModificationDate: 2022-10-24T19:36:57.774+01:00
+        hippostdpubwf:lastModificationDate: 2022-12-22T13:02:25.864Z
         hippostdpubwf:lastModifiedBy: admin
         hippotranslation:id: dd2936bb-ffea-47b4-ad39-4623cf91b2e1
         hippotranslation:locale: en
@@ -2094,14 +2097,15 @@
         hee:email: development@gmail.com
         hee:name: Development
         hee:organisation: HEE Development Organisation
-        hee:phoneNumber: +44 7575 731 776
+        hee:phoneExtension: ''
+        hee:phoneNumber: 0113 887 1725
         hee:website: http://hee.development.org
         hippo:availability: [preview]
         hippostd:retainable: false
         hippostd:state: unpublished
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-13T17:02:14.997+07:00
-        hippostdpubwf:lastModificationDate: 2022-10-24T19:37:03.058+01:00
+        hippostdpubwf:lastModificationDate: 2022-12-22T13:04:15.453Z
         hippostdpubwf:lastModifiedBy: admin
         hippotranslation:id: dd2936bb-ffea-47b4-ad39-4623cf91b2e1
         hippotranslation:locale: en
@@ -2115,16 +2119,17 @@
         hee:email: development@gmail.com
         hee:name: Development
         hee:organisation: HEE Development Organisation
-        hee:phoneNumber: +44 7575 731 776
+        hee:phoneExtension: ''
+        hee:phoneNumber: 0113 887 1725
         hee:website: http://hee.development.org
         hippo:availability: [live]
         hippostd:retainable: false
         hippostd:state: published
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2021-05-13T17:02:14.997+07:00
-        hippostdpubwf:lastModificationDate: 2022-10-24T19:37:03.058+01:00
+        hippostdpubwf:lastModificationDate: 2022-12-22T13:04:15.453Z
         hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2022-10-24T19:37:04.961+01:00
+        hippostdpubwf:publicationDate: 2022-12-22T13:04:17.136Z
         hippotranslation:id: dd2936bb-ffea-47b4-ad39-4623cf91b2e1
         hippotranslation:locale: en
   /contact-cards:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/department-contact.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/department-contact.ftl
@@ -1,4 +1,5 @@
 <#include "../../include/imports.ftl">
+<#include "../utils/phone-number-util.ftl">
 
 <#macro departmentContact department>
     <div class="nhsuk-contact__content">
@@ -14,7 +15,7 @@
         <div class="nhsuk-contact__secondary-info">
             <#if department.phoneNumber?has_content>
                 <p aria-label="Telephone">
-                    <a href="tel:${department.phoneNumber?replace(' ', '')}" title="Opens call">${department.phoneNumber}</a>
+                    <a href="tel:${getUKCountryCodePrefixedPhoneNumber(department.phoneNumber)?replace(' ', '')}" title="Opens call">${getUKCountryCodePrefixedPhoneNumber(department.phoneNumber)}</a>
                     ${department.phoneExtension?has_content?then('(Ext: ' + department.phoneExtension + ')', '')}
                 </p>
             </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-contact.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-contact.ftl
@@ -1,4 +1,5 @@
 <#include "../../include/imports.ftl">
+<#include "../utils/phone-number-util.ftl">
 
 <#macro personContact person isAuthor=false>
     <div class="nhsuk-contact__content">
@@ -52,7 +53,7 @@
         <div class="nhsuk-contact__secondary-info">
             <#if person.phoneNumber?has_content>
                 <p aria-label="Telephone">
-                    <a href="tel:${person.phoneNumber?replace(' ', '')}" title="Opens call">${person.phoneNumber}</a>
+                    <a href="tel:${getUKCountryCodePrefixedPhoneNumber(person.phoneNumber)?replace(' ', '')}" title="Opens call">${getUKCountryCodePrefixedPhoneNumber(person.phoneNumber)}</a>
                     ${person.phoneExtension?has_content?then('(Ext: ' + person.phoneExtension + ')', '')}
                 </p>
             </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-contact.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-contact.ftl
@@ -35,7 +35,9 @@
             <h3 class="nhsuk-contact__job-title" aria-label="Job Title">${person.jobTitle}</h3>
         </#if>
 
-        <#if person.departmentName?has_content>
+        <#if person.department??>
+            <h5 data-anchorlinksignore="true" aria-label="Department">${person.department.name}</h5>
+        <#elseif person.departmentName?has_content>
             <h5 data-anchorlinksignore="true" aria-label="Department">${person.departmentName}</h5>
         </#if>
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/utils/phone-number-util.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/utils/phone-number-util.ftl
@@ -1,0 +1,15 @@
+<#--  Returns UK country code (+44) prefixed phone number  -->
+<#function getUKCountryCodePrefixedPhoneNumber phoneNumber>
+    <#assign phoneNumberWithoutSpaces=phoneNumber?replace(' ', '')>
+    <#assign tidiedUpPhoneNumber=phoneNumber>
+
+    <#if (phoneNumberWithoutSpaces?length > 10)>
+        <#if phoneNumberWithoutSpaces?starts_with("0")>
+            <#assign tidiedUpPhoneNumber="${tidiedUpPhoneNumber[1..]}">
+        <#elseif phoneNumberWithoutSpaces?starts_with("44")>
+            <#assign tidiedUpPhoneNumber="${tidiedUpPhoneNumber[2..]}">
+        </#if>
+    </#if>
+
+    <#return "+44 ${tidiedUpPhoneNumber}">
+</#function>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/Person.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/Person.java
@@ -2,7 +2,7 @@ package uk.nhs.hee.web.beans;
 
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 import org.hippoecm.hst.content.beans.Node;
-
+import org.hippoecm.hst.content.beans.standard.HippoBean;
 
 @HippoEssentialsGenerated(internalName = "hee:person")
 @Node(jcrType = "hee:person")
@@ -67,6 +67,7 @@ public class Person extends BaseDocument {
     public String getBio() {
         return getSingleProperty("hee:bio");
     }
+
     @HippoEssentialsGenerated(internalName = "hee:twitter")
     public String getTwitter() {
         return getSingleProperty("hee:twitter");
@@ -80,5 +81,10 @@ public class Person extends BaseDocument {
     @HippoEssentialsGenerated(internalName = "hee:phoneExtension")
     public String getPhoneExtension() {
         return getSingleProperty("hee:phoneExtension");
+    }
+
+    @HippoEssentialsGenerated(internalName = "hee:department")
+    public HippoBean getDepartment() {
+        return getLinkedBean("hee:department", HippoBean.class);
     }
 }


### PR DESCRIPTION
- Person
  - Changed `departmentName` & `bio` fields to `view` only mode.
  - Updated `departmentName` & `bio` field captions to include ` (This field is being removed)` suffix.
  - Included an optional `department` link picker field right below the existing `departmentName` field.
  - Updated person contact freemarker template to render `department`/`departmentName` based on availability.
- Department
  - Changed `description` field to `view` only mode.
  - Updated `description` field caption to include ` (This field is being removed)` suffix.
- Person/Department
  - Amended phone number validation as per the latest requirement.
  - Changed `phoneNumber` field length to `13`.
  - Changed `phoneExtension` field length to `5`.
  - Added numeric validation for `phoneExtension` field.
  - Updated person/department contact freemarker templates to render phone numbers with UK country code (`+44`) prefixed.
  - `RemoveUKCountryCodeFromPhoneNumbers` script to remove UK country code prefixes (+44) from existing phone numbers.