### PR TITLE
[NWPS-1331] Impl. of 'Hide Author contact details' checkbox toggle for Blog post, News and Publication landing pages

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
@@ -115,6 +115,14 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: hippo:mirror
             hipposysedit:validators: [required]
+          /hideAuthorContactDetails:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:hideAuthorContactDetails
+            hipposysedit:primary: false
+            hipposysedit:type: Boolean
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -134,6 +142,7 @@ definitions:
           hee:author: ''
           hee:publicationDate: 0001-01-01T12:00:00Z
           hee:categories: []
+          hee:hideAuthorContactDetails: false
           /hee:pageLastNextReview:
             jcr:primaryType: hee:pageLastNextReview
             hee:lastReviewed: 0001-01-01T12:00:00Z
@@ -213,6 +222,15 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               nodetypes: ['hee:author']
+          /hideAuthorContactDetails:
+            jcr:primaryType: frontend:plugin
+            caption: Hide Author contact details
+            field: hideAuthorContactDetails
+            hint: Check the box to hide the authors email address and work address.
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
           /microHero:
             jcr:primaryType: frontend:plugin
             caption: Micro-hero image

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
@@ -114,6 +114,14 @@ definitions:
             hipposysedit:path: hee:authors
             hipposysedit:primary: false
             hipposysedit:type: hippo:mirror
+          /hideAuthorContactDetails:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:hideAuthorContactDetails
+            hipposysedit:primary: false
+            hipposysedit:type: Boolean
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -132,6 +140,7 @@ definitions:
           hee:summary: ''
           hee:author: ''
           hee:categories: []
+          hee:hideAuthorContactDetails: false
           /hee:relatedContent:
             jcr:primaryType: hee:contentCards
             hee:cardGroupSummary: ''
@@ -210,6 +219,15 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               nodetypes: ['hee:author']
+          /hideAuthorContactDetails:
+            jcr:primaryType: frontend:plugin
+            caption: Hide Author contact details
+            field: hideAuthorContactDetails
+            hint: Check the box to hide the authors email address and work address.
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
           /publicationDate:
             jcr:primaryType: frontend:plugin
             caption: Publication date

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/publicationLandingPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/publicationLandingPage.yaml
@@ -135,6 +135,14 @@ definitions:
             hipposysedit:path: hee:authors
             hipposysedit:primary: false
             hipposysedit:type: hippo:mirror
+          /hideAuthorContactDetails:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:hideAuthorContactDetails
+            hipposysedit:primary: false
+            hipposysedit:type: Boolean
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -158,6 +166,7 @@ definitions:
           hippotranslation:locale: document-type-locale
           hee:readTime: ''
           hee:updatedDate: 0001-01-01T12:00:00Z
+          hee:hideAuthorContactDetails: false
           /hee:logoGroup:
             jcr:primaryType: hippo:mirror
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
@@ -240,6 +249,15 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               nodetypes: ['hee:author']
+          /hideAuthorContactDetails:
+            jcr:primaryType: frontend:plugin
+            caption: Hide Author contact details
+            field: hideAuthorContactDetails
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+            hint: Check the box to hide the authors email address and work address.
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
           /publicationType:
             jcr:primaryType: frontend:plugin
             caption: Publication type

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/news.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/news.yaml
@@ -19,6 +19,7 @@
       jcr:uuid: 625c02f0-d009-44d0-b824-fa64e6ae62cd
       hee:author: Joe Bloggs
       hee:categories: []
+      hee:hideAuthorContactDetails: true
       hee:publicationDate: 2021-12-16T18:20:00Z
       hee:summary: A record number of new trainees have accepted placements to become
         GPs, new figures published by Health Education England reveal.
@@ -95,6 +96,7 @@
       jcr:uuid: 42cc15c0-32e9-43c1-bf2b-4a561310530f
       hee:author: Joe Bloggs
       hee:categories: []
+      hee:hideAuthorContactDetails: true
       hee:publicationDate: 2021-12-16T18:20:00Z
       hee:summary: A record number of new trainees have accepted placements to become
         GPs, new figures published by Health Education England reveal.
@@ -171,6 +173,7 @@
       jcr:uuid: 1582f76a-7f86-4cad-8233-5e5c52facea3
       hee:author: Joe Bloggs
       hee:categories: []
+      hee:hideAuthorContactDetails: true
       hee:publicationDate: 2021-12-16T18:20:00Z
       hee:summary: A record number of new trainees have accepted placements to become
         GPs, new figures published by Health Education England reveal.

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/publications.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/publications.yaml
@@ -30,6 +30,7 @@
           jcr:primaryType: hee:publicationLandingPage
           jcr:mixinTypes: ['mix:referenceable']
           jcr:uuid: 48e8515a-6a01-4e04-bb8e-6f06775f58f2
+          hee:hideAuthorContactDetails: true
           hee:publicationDate: 2022-11-28T00:00:00Z
           hee:publicationProfessions: [public_health]
           hee:publicationTopics: [knowledge_management, quality, workforce_planning,
@@ -102,6 +103,7 @@
           jcr:primaryType: hee:publicationLandingPage
           jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
           jcr:uuid: 0abfe671-b25a-49d9-adab-4288e720fd55
+          hee:hideAuthorContactDetails: true
           hee:publicationDate: 2022-11-28T00:00:00Z
           hee:publicationProfessions: [public_health]
           hee:publicationTopics: [knowledge_management, quality, workforce_planning,
@@ -174,6 +176,7 @@
           jcr:primaryType: hee:publicationLandingPage
           jcr:mixinTypes: ['mix:referenceable']
           jcr:uuid: 11dacd51-85cc-42b7-b3e6-dd7b9880a83a
+          hee:hideAuthorContactDetails: true
           hee:publicationDate: 2022-11-28T00:00:00Z
           hee:publicationProfessions: [public_health]
           hee:publicationTopics: [knowledge_management, quality, workforce_planning,

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
@@ -103,7 +103,7 @@
                         </#list>
 
                         <#--  Author cards  -->
-                        <@authorCards authors=document.authors/>
+                        <@authorCards authors=document.authors hideAuthorContactDetails=document.hideAuthorContactDetails!false/>
 
                         <#-- End Blog content -->
                         <@hee.lastNextReviewedDate lastNextReviewedDate=document.pageLastNextReview/>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/news-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/news-main.ftl
@@ -107,7 +107,7 @@
                                 </#list>
 
                                 <#--  Author cards  -->
-                                <@authorCards authors=document.authors/>
+                                <@authorCards authors=document.authors hideAuthorContactDetails=document.hideAuthorContactDetails!false/>
 
                                 <#-- End News content -->
                                 <@hee.lastNextReviewedDate lastNextReviewedDate=document.pageLastNextReview/>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
@@ -131,7 +131,7 @@
                                      </#if>
 
                                     <#--  Author cards  -->
-                                    <@authorCards authors=document.authors/>
+                                    <@authorCards authors=document.authors hideAuthorContactDetails=document.hideAuthorContactDetails!false/>
                                 </div>
                             </section>
                         </div>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/author-cards.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/author-cards.ftl
@@ -2,10 +2,10 @@
 <#include "person-author.ftl">
 
 <#--  Renders Author cards  -->
-<#macro authorCards authors>
+<#macro authorCards authors hideAuthorContactDetails>
     ${(authors?size gt 1)?then('<div class="hee-card--author__container">', '')}
     <#list authors as author>
-        <@personAuthor person=author.person bioSummary=author.bioSummary />
+        <@personAuthor person=author.person bioSummary=author.bioSummary hideAuthorContactDetails=hideAuthorContactDetails />
     </#list>
     ${(authors?size gt 1)?then('</div>', '')}
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-author.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-author.ftl
@@ -1,7 +1,7 @@
 <#include "../../include/imports.ftl">
 
 <#--  Renders Person for Author card  -->
-<#macro personAuthor person bioSummary>
+<#macro personAuthor person bioSummary hideAuthorContactDetails>
     <div class="hee-card hee-card--author">
 
         <#--  Author header  -->
@@ -64,19 +64,13 @@
 
         <#--  Author contact details  -->
         <ul class="hee-card__contact">
-            <#--  TODO: Phone number & extension  -->
-            <#--  <#if person.phoneNumber?has_content>
-                <li class="hee-card__phone hee-card__contact__item" aria-label="Telephone">
-                    <a href="tel:${person.phoneNumber?replace(' ', '')}" title="Opens call">${person.phoneNumber}</a>
-                    ${person.phoneExtension?has_content?then('(Ext: ' + person.phoneExtension + ')', '')}
-                </li>
-            </#if>  -->
-
-            <#--  Email  -->
-            <#if person.email?has_content>
-                <li class="hee-card__email hee-card__contact__item" aria-label="Email">
-                    <a href="mailto:${person.email}" title="Opens email">${person.email}</a>
-                </li>
+            <#if !hideAuthorContactDetails>
+                <#--  Email  -->
+                <#if person.email?has_content>
+                    <li class="hee-card__email hee-card__contact__item" aria-label="Email">
+                        <a href="mailto:${person.email}" title="Opens email">${person.email}</a>
+                    </li>
+                </#if>
             </#if>
 
             <#--  Website  -->
@@ -101,9 +95,11 @@
             </#if>
         </ul>
 
-        <#--  Address  -->
-        <#if person.address?has_content>
-            <p class="hee-card__address" aria-label="Address">${person.address?replace('\n', '<br>')}</p>
+        <#if !hideAuthorContactDetails>
+            <#--  Address  -->
+            <#if person.address?has_content>
+                <p class="hee-card__address" aria-label="Address">${person.address?replace('\n', '<br>')}</p>
+            </#if>
         </#if>
 
         <#--  Bio summary  -->

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/BlogPost.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/BlogPost.java
@@ -69,4 +69,9 @@ public class BlogPost extends BaseDocument {
     public List<HippoBean> getAuthors() {
         return getLinkedBeans("hee:authors", HippoBean.class);
     }
+
+    @HippoEssentialsGenerated(internalName = "hee:hideAuthorContactDetails")
+    public Boolean getHideAuthorContactDetails() {
+        return getSingleProperty("hee:hideAuthorContactDetails");
+    }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/News.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/News.java
@@ -69,4 +69,9 @@ public class News extends BaseDocument {
     public List<HippoBean> getAuthors() {
         return getLinkedBeans("hee:authors", HippoBean.class);
     }
+
+    @HippoEssentialsGenerated(internalName = "hee:hideAuthorContactDetails")
+    public Boolean getHideAuthorContactDetails() {
+        return getSingleProperty("hee:hideAuthorContactDetails");
+    }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/PublicationLandingPage.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/PublicationLandingPage.java
@@ -89,4 +89,9 @@ public class PublicationLandingPage extends BaseDocument {
     public List<HippoBean> getAuthors() {
         return getLinkedBeans("hee:authors", HippoBean.class);
     }
+
+    @HippoEssentialsGenerated(internalName = "hee:hideAuthorContactDetails")
+    public Boolean getHideAuthorContactDetails() {
+        return getSingleProperty("hee:hideAuthorContactDetails");
+    }
 }


### PR DESCRIPTION
- Added `Hide Author contact details` optional check box field (defaulting to `unchecked`) right below the `Authors` field on the `Blog post`, `News` and `Publication landing page` documents.
- Updated Author card-related freemarker templates to not render email & work address if `Hide Author contact details` is `checked`.