### PR TITLE
[NWPS-1340]: Publication page document type and freemarker updates

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/report.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/report.yaml
@@ -98,14 +98,10 @@ definitions:
             hee:lastReviewed: 0001-01-01T12:00:00Z
             hee:nextReviewed: 0001-01-01T12:00:00Z
           /hee:contentBlocks:
-            jcr:primaryType: hee:anchorLinks
-            hee:targetHeadings: [h2, h3, h4, h5]
-            hee:title: On this page
-          /hee:contentBlocks[2]:
             jcr:primaryType: hee:headingsTOC
             hee:headingTitle: ''
             hee:shortTitle: ''
-          /hee:contentBlocks[3]:
+          /hee:contentBlocks[2]:
             jcr:primaryType: hippostd:html
             hippostd:content: ''
           /hee:logoGroup:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/publications.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/publications.yaml
@@ -1255,7 +1255,7 @@
         jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
         jcr:uuid: 4dd66eef-a298-40a4-af75-dd1674bc3824
         hippo:name: Higher Specialist Scientist Training – Publication
-        hippo:versionHistory: f28e2965-d27e-41d3-92be-99ec748cb1f9
+        hippo:versionHistory: 8910e5c9-38c7-4e1e-9c2a-8ac5ef445a57
         /higher-specialist-scientist-training---publication[1]:
           jcr:primaryType: hee:report
           jcr:mixinTypes: ['mix:referenceable']
@@ -1270,7 +1270,7 @@
           hippostd:state: draft
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T21:34:32.235Z
-          hippostdpubwf:lastModificationDate: 2022-11-28T21:34:32.235Z
+          hippostdpubwf:lastModificationDate: 2023-01-25T11:32:13.084Z
           hippostdpubwf:lastModifiedBy: admin
           hippotranslation:id: 427e04b6-e013-47b1-bf41-14bdda7caad7
           hippotranslation:locale: en
@@ -1278,11 +1278,7 @@
             jcr:primaryType: hee:pageLastNextReview
             hee:lastReviewed: 2022-11-28T00:00:00Z
             hee:nextReviewed: 2022-11-30T00:00:00Z
-          /hee:contentBlocks[1]:
-            jcr:primaryType: hee:anchorLinks
-            hee:targetHeadings: [h2, h3, h4, h5]
-            hee:title: On this page
-          /hee:contentBlocks[2]:
+          /hee:contentBlocks:
             jcr:primaryType: hippostd:html
             hippostd:content: |-
               <h2>Advancing your clinical and scientific skills for patient and public benefit</h2>
@@ -1336,7 +1332,7 @@
           hippostd:state: unpublished
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T21:34:32.235Z
-          hippostdpubwf:lastModificationDate: 2022-11-28T21:35:46.150Z
+          hippostdpubwf:lastModificationDate: 2023-01-25T11:32:27.404Z
           hippostdpubwf:lastModifiedBy: admin
           hippotranslation:id: 427e04b6-e013-47b1-bf41-14bdda7caad7
           hippotranslation:locale: en
@@ -1344,11 +1340,7 @@
             jcr:primaryType: hee:pageLastNextReview
             hee:lastReviewed: 2022-11-28T00:00:00Z
             hee:nextReviewed: 2022-11-30T00:00:00Z
-          /hee:contentBlocks[1]:
-            jcr:primaryType: hee:anchorLinks
-            hee:targetHeadings: [h2, h3, h4, h5]
-            hee:title: On this page
-          /hee:contentBlocks[2]:
+          /hee:contentBlocks:
             jcr:primaryType: hippostd:html
             hippostd:content: |-
               <h2>Advancing your clinical and scientific skills for patient and public benefit</h2>
@@ -1402,20 +1394,16 @@
           hippostd:state: published
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T21:34:32.235Z
-          hippostdpubwf:lastModificationDate: 2022-11-28T21:35:46.150Z
+          hippostdpubwf:lastModificationDate: 2023-01-25T11:32:27.404Z
           hippostdpubwf:lastModifiedBy: admin
-          hippostdpubwf:publicationDate: 2022-11-28T21:53:36.035Z
+          hippostdpubwf:publicationDate: 2023-01-25T11:32:33.738Z
           hippotranslation:id: 427e04b6-e013-47b1-bf41-14bdda7caad7
           hippotranslation:locale: en
           /hee:pageLastNextReview:
             jcr:primaryType: hee:pageLastNextReview
             hee:lastReviewed: 2022-11-28T00:00:00Z
             hee:nextReviewed: 2022-11-30T00:00:00Z
-          /hee:contentBlocks[1]:
-            jcr:primaryType: hee:anchorLinks
-            hee:targetHeadings: [h2, h3, h4, h5]
-            hee:title: On this page
-          /hee:contentBlocks[2]:
+          /hee:contentBlocks:
             jcr:primaryType: hippostd:html
             hippostd:content: |-
               <h2>Advancing your clinical and scientific skills for patient and public benefit</h2>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/report-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/report-main.ftl
@@ -4,7 +4,6 @@
 <#import "../macros/components.ftl" as hee>
 <#include "../macros/back-link.ftl">
 <#include "../utils/date-util.ftl">
-<#include "../utils/document-formats.ftl">
 
 <@hst.setBundle basename="uk.nhs.hee.web.global"/>
 
@@ -17,7 +16,7 @@
 
     <div class="hee-card--details__item">
         <a class="hee-resources__link" href="${fileURL}" title="${docLink.filename}">
-            <span class="hee-resources__text">${docLink.filename?keep_before_last(".")} - ${getDocumentFormat(docLink.filename?keep_after_last("."))}</span>
+            <span class="hee-resources__text">${docLink.filename?keep_before_last(".")}</span>
             <span class="hee-resources__tag hee-resources__${docType}">${docType?upper_case}</span>
         </a>
     </div>


### PR DESCRIPTION
- Removed default `Anchor links` content block from the `Main content objects` field.
- `Anchor links` dev content block content tidy up.
- Removed document format rendering from `Alternative versions` and `Languages` sidebar cards.

**Note** that the `Main content objects` field default `Anchor links` content block (`/hippo:namespaces/hee/report/hipposysedit:prototypes/hipposysedit:prototype/hee:contentBlocks
`) should manually be deleted from the environment to which this change will be deployed:
![report-aka-publication-page-default-anchor-links-component](https://user-images.githubusercontent.com/35143542/214553358-0c469ed0-64c6-4ee4-bd5d-eda7d727cef0.png)
