### PR TITLE
[NWPS-1144] Inclusion of Publication landing pages in search results

### DIFF
--- a/repository-data/application/src/main/resources/hcm-actions.yaml
+++ b/repository-data/application/src/main/resources/hcm-actions.yaml
@@ -62,3 +62,5 @@ action-lists:
       /content/documents/administration/valuelists/publicationprofessions: reload
   - 1.0.34:
       /content/documents/administration/labels/listing: reload
+  - 1.0.35:
+      /content/documents/administration/valuelists/documenttypes: reload

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/documenttypes.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/valuelists/documenttypes.yaml
@@ -18,19 +18,19 @@
     /selection:listitem[2]:
       jcr:primaryType: selection:listitem
       selection:key: hee:guidance
-      selection:label: Standard Content Page
+      selection:label: Standard content page
     /selection:listitem[3]:
       jcr:primaryType: selection:listitem
       selection:key: hee:landingPage
-      selection:label: Landing Page
+      selection:label: Landing page
     /selection:listitem[4]:
       jcr:primaryType: selection:listitem
       selection:key: hee:MiniHub
-      selection:label: MiniHub
+      selection:label: Mini-hub
     /selection:listitem[5]:
       jcr:primaryType: selection:listitem
       selection:key: hee:blogPost
-      selection:label: BlogPost
+      selection:label: Blog post
     /selection:listitem[6]:
       jcr:primaryType: selection:listitem
       selection:key: hee:event
@@ -38,16 +38,20 @@
     /selection:listitem[7]:
       jcr:primaryType: selection:listitem
       selection:key: hee:listingPage
-      selection:label: ListingPage
+      selection:label: Listing page
     /selection:listitem[8]:
       jcr:primaryType: selection:listitem
       selection:key: hee:caseStudy
-      selection:label: CaseStudy
+      selection:label: Case study
     /selection:listitem[9]:
       jcr:primaryType: selection:listitem
       selection:key: hee:searchBank
-      selection:label: SearchBank
+      selection:label: Search bank
     /selection:listitem[10]:
       jcr:primaryType: selection:listitem
       selection:key: hee:news
-      selection:label: News
+      selection:label: News article
+    /selection:listitem[11]:
+      jcr:primaryType: selection:listitem
+      selection:key: hee:publicationLandingPage
+      selection:label: Publication landing

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/listing-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/listing-pages.yaml
@@ -97,24 +97,27 @@
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
     jcr:uuid: 6d95c002-0535-41b3-8669-619735ecf394
     hippo:name: Search Results
-    hippo:versionHistory: 1146a77d-b857-49b1-90a2-c591f10dce82
+    hippo:versionHistory: 62afa439-a896-4f9c-9f99-4695e80a9fbd
     /search-results[1]:
       jcr:primaryType: hee:listingPage
       jcr:mixinTypes: ['mix:referenceable']
       jcr:uuid: e734ac17-0503-4c18-a111-7ea5d4ab8e9d
+      hee:addToAZ: false
       hee:documentTypes: ['hee:guidance', 'hee:landingPage', 'hee:bulletin', 'hee:MiniHub',
-        'hee:blogPost', 'hee:event', 'hee:caseStudy', 'hee:listingPage', 'hee:searchBank']
+        'hee:blogPost', 'hee:event', 'hee:caseStudy', 'hee:listingPage', 'hee:searchBank',
+        'hee:publicationLandingPage']
       hee:listingPageType: search
       hee:pageSize: 10
       hee:path: ''
       hee:summary: Search for terms within guidance pages and blog posts.
       hee:title: Search
       hippo:availability: []
+      hippostd:holder: admin
       hippostd:retainable: false
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-03-31T14:41:37.258+07:00
-      hippostdpubwf:lastModificationDate: 2021-11-08T01:00:12.627Z
+      hippostdpubwf:lastModificationDate: 2023-02-13T11:22:28.842Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: f7eef939-123a-4465-878a-1b4c94be9e4c
       hippotranslation:locale: en
@@ -128,8 +131,10 @@
       jcr:primaryType: hee:listingPage
       jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
       jcr:uuid: b843cfa2-5737-46f9-bba2-10d0d067a803
+      hee:addToAZ: false
       hee:documentTypes: ['hee:guidance', 'hee:landingPage', 'hee:bulletin', 'hee:MiniHub',
-        'hee:blogPost', 'hee:event', 'hee:caseStudy', 'hee:listingPage', 'hee:searchBank']
+        'hee:blogPost', 'hee:event', 'hee:caseStudy', 'hee:listingPage', 'hee:searchBank',
+        'hee:publicationLandingPage']
       hee:listingPageType: search
       hee:pageSize: 10
       hee:path: ''
@@ -140,7 +145,7 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-03-31T14:41:37.258+07:00
-      hippostdpubwf:lastModificationDate: 2021-11-08T01:00:16.780Z
+      hippostdpubwf:lastModificationDate: 2023-02-13T11:16:30.791Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: f7eef939-123a-4465-878a-1b4c94be9e4c
       hippotranslation:locale: en
@@ -154,8 +159,10 @@
       jcr:primaryType: hee:listingPage
       jcr:mixinTypes: ['mix:referenceable']
       jcr:uuid: ac0dc40d-426f-4299-840e-929ebf3d6a53
+      hee:addToAZ: false
       hee:documentTypes: ['hee:guidance', 'hee:landingPage', 'hee:bulletin', 'hee:MiniHub',
-        'hee:blogPost', 'hee:event', 'hee:caseStudy', 'hee:listingPage', 'hee:searchBank']
+        'hee:blogPost', 'hee:event', 'hee:caseStudy', 'hee:listingPage', 'hee:searchBank',
+        'hee:publicationLandingPage']
       hee:listingPageType: search
       hee:pageSize: 10
       hee:path: ''
@@ -166,9 +173,9 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-03-31T14:41:37.258+07:00
-      hippostdpubwf:lastModificationDate: 2021-11-08T01:00:16.780Z
+      hippostdpubwf:lastModificationDate: 2023-02-13T11:16:30.791Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2021-11-08T01:00:18.389Z
+      hippostdpubwf:publicationDate: 2023-02-13T11:16:32.551Z
       hippotranslation:id: f7eef939-123a-4465-878a-1b4c94be9e4c
       hippotranslation:locale: en
       /hee:heroImage:

--- a/site/components/src/main/java/uk/nhs/hee/web/components/SearchResultsComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/SearchResultsComponent.java
@@ -7,14 +7,6 @@ import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
 import org.hippoecm.hst.core.parameters.ParametersInfo;
 import org.onehippo.cms7.essentials.components.info.EssentialsDocumentComponentInfo;
-import uk.nhs.hee.web.beans.ListingPage;
-import uk.nhs.hee.web.utils.HstUtils;
-import uk.nhs.hee.web.utils.StringUtils;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 


### PR DESCRIPTION
- Updated `/content/documents/administration/valuelists/documenttypes` value-list to include `Publication landing` (`hee:publicationLandingPage`) document type so as to include it for `Search Results` listing page document. Also, updated `value` field of `/content/documents/administration/valuelists/documenttypes` to follow the sentence case naming convention.
- Included reloading action for `/content/documents/administration/valuelists/documenttypes` value-list via `repository-data/application/src/main/resources/hcm-actions.yaml`