### PR TITLE
[NWPS-1090] Update contact component and allow addition of description

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-contact-card-description.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-contact-card-description.yaml
@@ -1,0 +1,10 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:queries/hippo:templates/new-contact-card-description:
+      jcr:primaryType: hippostd:templatequery
+      hippostd:modify: [./_name, $name, './hippotranslation:locale', $inherited, './hippotranslation:id',
+        $uuid, './hippostdpubwf:createdBy', $holder, './hippostdpubwf:creationDate',
+        $now, './hippostdpubwf:lastModifiedBy', $holder, './hippostdpubwf:lastModificationDate',
+        $now, './hippostd:holder', $holder]
+      jcr:language: xpath
+      jcr:statement: //element(*,hipposysedit:namespacefolder)/element(*,mix:referenceable)/element(*,hipposysedit:templatetype)/hipposysedit:prototypes/element(hipposysedit:prototype,hee:contactCardWithDescription)

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
@@ -20,7 +20,7 @@ definitions:
       new-richtext-block: new rich text
       new-department: new department
       new-person: new person
-      new-contact-card: new contact card
+      new-contact-card-description: new contact card
       new-blogPost-document: new blog post document
       new-caseStudy-document: new case study document
       new-caseStudy-folder: new case study folder

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
@@ -66,7 +66,7 @@ definitions:
       jcr:primaryType: hipposys:resourcebundles
       /en:
         jcr:primaryType: hipposys:resourcebundle
-        jcr:name: Card - Contact
+        jcr:name: Card - Contact (Old)
     /hippo:configuration/hippo:translations/hippo:types/hee:blockLinksReference:
       jcr:primaryType: hipposys:resourcebundles
       /en:
@@ -141,7 +141,7 @@ definitions:
       jcr:primaryType: hipposys:resourcebundles
       /en:
         jcr:primaryType: hipposys:resourcebundle
-        jcr:name: '[Content block][Side] Card - Contact'
+        jcr:name: '[Content Block][Main] Card - Contact (Old)'
     /hippo:configuration/hippo:translations/hippo:types/hee:externalLinksCard:
       jcr:primaryType: hipposys:resourcebundles
       /en:
@@ -426,3 +426,13 @@ definitions:
       jcr:name: '[Settings] Form'
     /hippo:configuration/hippo:translations/hippo:types/hippo:facetselect/en:
       jcr:name: Faceted link
+    /hippo:configuration/hippo:translations/hippo:types/hee:contactCardWithDescriptionReference:
+      jcr:primaryType: hipposys:resourcebundles
+      /en:
+        jcr:primaryType: hipposys:resourcebundle
+        jcr:name: Card - Contact
+    /hippo:configuration/hippo:translations/hippo:types/hee:contactCardWithDescription:
+      jcr:primaryType: hipposys:resourcebundles
+      /en:
+        jcr:primaryType: hipposys:resourcebundle
+        jcr:name: '[Content Block][Side] Card - Contact'

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
@@ -141,7 +141,7 @@ definitions:
       jcr:primaryType: hipposys:resourcebundles
       /en:
         jcr:primaryType: hipposys:resourcebundle
-        jcr:name: '[Content Block][Main] Card - Contact (Old)'
+        jcr:name: '[Content block][Main] Card - Contact (Old)'
     /hippo:configuration/hippo:translations/hippo:types/hee:externalLinksCard:
       jcr:primaryType: hipposys:resourcebundles
       /en:
@@ -435,4 +435,4 @@ definitions:
       jcr:primaryType: hipposys:resourcebundles
       /en:
         jcr:primaryType: hipposys:resourcebundle
-        jcr:name: '[Content Block][Side] Card - Contact'
+        jcr:name: '[Content block][Side] Card - Contact'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
@@ -92,6 +92,12 @@
 [hee:contactCardReference] > hippo:compound, hippostd:relaxed
   orderable
 
+[hee:contactCardWithDescription] > hee:basedocument, hippostd:relaxed, hippotranslation:translated
+  orderable
+
+[hee:contactCardWithDescriptionReference] > hippo:compound, hippostd:relaxed
+  orderable
+
 [hee:contactWithCopy] > hippo:compound, hippostd:relaxed
   orderable
 
@@ -263,3 +269,4 @@
 
 [hee:warningCalloutReference] > hippo:compound, hippostd:relaxed
   orderable
+

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
@@ -134,7 +134,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contact,hee:contentCards,hee:detailsReference,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:navMap,hee:richTextReference,hee:statementCardReference,hee:tableReference,hee:tabsReference,hee:warningCalloutReference
+            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contentCards,hee:detailsReference,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:navMap,hee:richTextReference,hee:statementCardReference,hee:tableReference,hee:tabsReference,hee:warningCalloutReference
             contentPickerType: links
             field: contentBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
@@ -287,7 +287,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:anchorLinks,hee:blockLinksReference,hee:contact,hee:contentCards,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:richTextReference,hee:tableReference,hee:tabsReference,hee:warningCalloutReference
+            compoundList: hee:anchorLinks,hee:blockLinksReference,hee:contentCards,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:richTextReference,hee:tableReference,hee:tabsReference,hee:warningCalloutReference
             contentPickerType: links
             field: contentBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
@@ -299,7 +299,7 @@ definitions:
           /rightHandBlocks:
             jcr:primaryType: frontend:plugin
             caption: Right hand objects
-            compoundList: hee:contactCardReference,hee:externalLinksCardReference,hee:fileLinksCardReference,hee:internalLinksCardReference,hee:QuickLinks
+            compoundList: hee:contactCardWithDescriptionReference,hee:externalLinksCardReference,hee:fileLinksCardReference,hee:internalLinksCardReference,hee:QuickLinks
             contentPickerType: links
             field: rightHandBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/contactCardWithDescription.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/contactCardWithDescription.yaml
@@ -1,0 +1,82 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/contactCardWithDescription:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: 3e68e6ae-6cd8-4226-9838-78273170201a
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: e216829a-b926-4352-bab1-33d47b619476
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
+          jcr:uuid: a0ebcdbd-7fa9-460f-8ff3-2d0bac4ee85c
+          hipposysedit:node: true
+          hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
+          hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
+          /description:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:description
+            hipposysedit:primary: false
+            hipposysedit:type: String
+          /contactCardReference:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:contactCardReference
+            hipposysedit:primary: false
+            hipposysedit:type: hee:contactCardReference
+            hipposysedit:validators: [required]
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:contactCardWithDescription
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          jcr:mixinTypes: ['mix:referenceable']
+          hee:description: ''
+          jcr:uuid: 81dd125b-f664-4430-97d4-85495311691c
+          hippostdpubwf:lastModificationDate: 2023-02-13T16:53:10.253Z
+          hippostdpubwf:creationDate: 2023-02-13T16:53:10.254Z
+          /hee:contactCardReference:
+            jcr:primaryType: hee:contactCardReference
+            /hee:content:
+              jcr:primaryType: hippo:mirror
+              hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
+          frontend:services: [wicket.id, validator.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /contactCardReference:
+            jcr:primaryType: frontend:plugin
+            caption: Contact Card
+            field: contactCardReference
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+          /description:
+            jcr:primaryType: frontend:plugin
+            caption: Description
+            field: description
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+            hint: ''
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/contactCardWithDescriptionReference.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/contactCardWithDescriptionReference.yaml
@@ -1,0 +1,53 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/contactCardWithDescriptionReference:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: e074f4b0-ca81-433b-9add-b0ed6e97454a
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 693d7555-fd53-4425-a856-a896127a5e9b
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
+          jcr:uuid: 8ceaa1cc-3d08-4900-bacb-2533a1b53553
+          hipposysedit:node: true
+          hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
+          hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
+          /contactCardWithDescription:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: hee:contactCardWithDescription
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:mirror
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:contactCardWithDescriptionReference
+          /hee:contactCardWithDescription:
+            jcr:primaryType: hippo:mirror
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
+          frontend:services: [wicket.id, validator.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /contactCardWithDescription:
+            jcr:primaryType: frontend:plugin
+            caption: Contact Card With Description
+            field: contactCardWithDescription
+            hint: ''
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              nodetypes: ['hee:contactCardWithDescription']

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
@@ -197,7 +197,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:ActionLink,hee:anchorLinks,hee:appliesToBoxReference,hee:blockLinksReference,hee:buttonReference,hee:contact,hee:contentCards,hee:detailsReference,hee:expanderGroupReference,hippostd:html,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:navMap,hee:newsletterSubscribeFormReference,hee:richTextReference,hee:statementCardReference,hee:tableReference,hee:tabsReference,hee:warningCalloutReference
+            compoundList: hee:ActionLink,hee:anchorLinks,hee:appliesToBoxReference,hee:blockLinksReference,hee:buttonReference,hee:contentCards,hee:detailsReference,hee:expanderGroupReference,hippostd:html,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:navMap,hee:newsletterSubscribeFormReference,hee:richTextReference,hee:statementCardReference,hee:tableReference,hee:tabsReference,hee:warningCalloutReference
             contentPickerType: links
             field: contentBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
@@ -209,7 +209,7 @@ definitions:
           /rightHandBlocks:
             jcr:primaryType: frontend:plugin
             caption: Right hand objects
-            compoundList: hee:contactCardReference,hee:ctaCardReference,hee:externalLinksCardReference,hee:fileLinksCardReference,hee:internalLinksCardReference,hee:QuickLinks,hee:rightHandImageReference
+            compoundList: hee:contactCardWithDescriptionReference,hee:ctaCardReference,hee:externalLinksCardReference,hee:fileLinksCardReference,hee:internalLinksCardReference,hee:QuickLinks,hee:rightHandImageReference
             contentPickerType: links
             field: rightHandBlocks
             hint: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
@@ -266,7 +266,7 @@ definitions:
           /rightHandBlocks:
             jcr:primaryType: frontend:plugin
             caption: Right hand objects
-            compoundList: hee:contactCardReference,hee:ctaCardReference,hee:externalLinksCardReference,hee:fileLinksCardReference,hee:QuickLinks
+            compoundList: hee:contactCardWithDescriptionReference,hee:ctaCardReference,hee:externalLinksCardReference,hee:fileLinksCardReference,hee:QuickLinks
             contentPickerType: links
             field: rightHandBlocks
             hint: ''
@@ -294,7 +294,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contact,hee:contentCards,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:richTextReference,hee:statementCardReference,hee:tableReference,hee:tabsReference,hee:warningCalloutReference
+            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contentCards,hippostd:html,hippogallerypicker:imagelink,hee:mediaEmbedReference,hee:richTextReference,hee:statementCardReference,hee:tableReference,hee:tabsReference,hee:warningCalloutReference
             contentPickerType: links
             field: contentBlocks
             hint: ''

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/lks/contact-card-summary-one.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/lks/contact-card-summary-one.yaml
@@ -1,0 +1,64 @@
+/content/documents/lks/contact-card-summary-one:
+  jcr:primaryType: hippo:handle
+  jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+  jcr:uuid: 247dd9b4-9039-47b3-b003-7945d28471ac
+  hippo:name: contact card summary one
+  hippo:versionHistory: 1d78b0c9-5522-4180-88a3-1bb87ad0e184
+  /contact-card-summary-one[1]:
+    jcr:primaryType: hee:contactCardWithDescription
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: d2472b4c-791f-4318-a3ad-a7e29d9dc1d8
+    hee:description: ''
+    hippo:availability: []
+    hippostd:retainable: false
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2023-02-13T17:21:45.292Z
+    hippostdpubwf:lastModificationDate: 2023-02-15T12:13:56.484Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: b7088479-20d9-4e55-8363-cda60c621a3f
+    hippotranslation:locale: en
+    /hee:contactCardReference:
+      jcr:primaryType: hee:contactCardReference
+      /hee:content:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
+  /contact-card-summary-one[2]:
+    jcr:primaryType: hee:contactCardWithDescription
+    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+    jcr:uuid: 0b98e8ce-2da1-46d2-b6c2-7109b99e737a
+    hee:description: ''
+    hippo:availability: [preview]
+    hippostd:retainable: false
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2023-02-13T17:21:45.292Z
+    hippostdpubwf:lastModificationDate: 2023-02-15T12:13:59.763Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: b7088479-20d9-4e55-8363-cda60c621a3f
+    hippotranslation:locale: en
+    /hee:contactCardReference:
+      jcr:primaryType: hee:contactCardReference
+      /hee:content:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
+  /contact-card-summary-one[3]:
+    jcr:primaryType: hee:contactCardWithDescription
+    jcr:mixinTypes: ['mix:referenceable']
+    jcr:uuid: 53715f4c-1fdb-4914-ae41-b05b533d6d5e
+    hee:description: ''
+    hippo:availability: [live]
+    hippostd:retainable: false
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2023-02-13T17:21:45.292Z
+    hippostdpubwf:lastModificationDate: 2023-02-15T12:13:59.763Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2023-02-15T12:14:02.850Z
+    hippotranslation:id: b7088479-20d9-4e55-8363-cda60c621a3f
+    hippotranslation:locale: en
+    /hee:contactCardReference:
+      jcr:primaryType: hee:contactCardReference
+      /hee:content:
+        jcr:primaryType: hippo:mirror
+        hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
@@ -3190,9 +3190,72 @@
     jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
     jcr:uuid: 8e26dbf7-3f65-4a25-a02f-af4bdbccf826
     hippo:name: Contact Cards
-    hippostd:foldertype: [new-contact-card]
+    hippostd:foldertype: [new-contact-card-description]
     hippotranslation:id: 4de2c8c8-e599-4514-9d99-526fbc324095
     hippotranslation:locale: en
+    /fred222:
+      jcr:primaryType: hippo:handle
+      jcr:mixinTypes: ['hippo:versionInfo', 'mix:referenceable']
+      jcr:uuid: 8a27aa67-f44b-4a98-9550-5a94a9c0edf2
+      hippo:versionHistory: 494ed115-5ef5-41fc-a74f-ac40f966b4ae
+      /fred222[1]:
+        jcr:primaryType: hee:contactCardWithDescription
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 9f242d96-b67f-47e3-9867-f2d3affbc9bb
+        hee:description: James is an absolute legend
+        hippo:availability: []
+        hippostd:retainable: false
+        hippostd:state: draft
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2023-02-15T15:23:57.282Z
+        hippostdpubwf:lastModificationDate: 2023-02-15T15:23:57.282Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippotranslation:id: 62db6ba8-29a3-45bd-85c2-703693333b15
+        hippotranslation:locale: en
+        /hee:contactCardReference:
+          jcr:primaryType: hee:contactCardReference
+          /hee:content:
+            jcr:primaryType: hippo:mirror
+            hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
+      /fred222[2]:
+        jcr:primaryType: hee:contactCardWithDescription
+        jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+        jcr:uuid: 84581b3c-54e3-4a25-a438-457d9a298611
+        hee:description: James is an absolute legend
+        hippo:availability: [preview]
+        hippostd:retainable: false
+        hippostd:state: unpublished
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2023-02-15T15:23:57.282Z
+        hippostdpubwf:lastModificationDate: 2023-02-15T15:24:23.113Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippotranslation:id: 62db6ba8-29a3-45bd-85c2-703693333b15
+        hippotranslation:locale: en
+        /hee:contactCardReference:
+          jcr:primaryType: hee:contactCardReference
+          /hee:content:
+            jcr:primaryType: hippo:mirror
+            hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
+      /fred222[3]:
+        jcr:primaryType: hee:contactCardWithDescription
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: db922df3-3d13-49b6-af90-c630e80f543e
+        hee:description: James is an absolute legend
+        hippo:availability: [live]
+        hippostd:retainable: false
+        hippostd:state: published
+        hippostdpubwf:createdBy: admin
+        hippostdpubwf:creationDate: 2023-02-15T15:23:57.282Z
+        hippostdpubwf:lastModificationDate: 2023-02-15T15:24:23.113Z
+        hippostdpubwf:lastModifiedBy: admin
+        hippostdpubwf:publicationDate: 2023-02-15T15:24:25.438Z
+        hippotranslation:id: 62db6ba8-29a3-45bd-85c2-703693333b15
+        hippotranslation:locale: en
+        /hee:contactCardReference:
+          jcr:primaryType: hee:contactCardReference
+          /hee:content:
+            jcr:primaryType: hippo:mirror
+            hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
   /external-links-cards:
     jcr:primaryType: hippostd:folder
     jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/guidance-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/guidance-pages.yaml
@@ -368,22 +368,22 @@
         /hee:buttonContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: 335a1882-5d19-4e01-a557-97c7da9225e6
-      /hee:contentBlocks[21]:
+      /hee:contentBlocks[20]:
         jcr:primaryType: hee:warningCalloutReference
         /hee:warningCalloutContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: a5d0aec9-f46e-4505-9c17-7fc6bf27403f
-      /hee:contentBlocks[22]:
+      /hee:contentBlocks[21]:
         jcr:primaryType: hee:warningCalloutReference
         /hee:warningCalloutContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: cabc00bf-bd7f-4d0f-89e3-920fa0729bf1
-      /hee:contentBlocks[23]:
+      /hee:contentBlocks[22]:
         jcr:primaryType: hee:statementCardReference
         /hee:statementCardContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: 9a99e45b-2ab1-4c15-a23a-93ee0bb7b1ed
-      /hee:contentBlocks[24]:
+      /hee:contentBlocks[23]:
         jcr:primaryType: hee:statementCardReference
         /hee:statementCardContentBlock:
           jcr:primaryType: hippo:mirror
@@ -394,7 +394,7 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
-      /hee:contentBlocks[25]:
+      /hee:contentBlocks[24]:
         jcr:primaryType: hee:appliesToBoxReference
         /hee:appliesToBoxReference:
           jcr:primaryType: hippo:mirror
@@ -402,11 +402,11 @@
         /hee:appliesToContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: ec2ddf5d-136e-4006-bc89-c9e1cee4e98f
-      /hee:contentBlocks[26]:
+      /hee:contentBlocks[25]:
         jcr:primaryType: hee:anchorLinks
         hee:targetHeadings: [h2]
         hee:title: On this page123
-      /hee:contentBlocks[27]:
+      /hee:contentBlocks[26]:
         jcr:primaryType: hee:navMap
         hee:mapEducation: dental
         hee:title: Dental Test
@@ -873,22 +873,22 @@
         /hee:buttonContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: 335a1882-5d19-4e01-a557-97c7da9225e6
-      /hee:contentBlocks[21]:
+      /hee:contentBlocks[20]:
         jcr:primaryType: hee:warningCalloutReference
         /hee:warningCalloutContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: a5d0aec9-f46e-4505-9c17-7fc6bf27403f
-      /hee:contentBlocks[22]:
+      /hee:contentBlocks[21]:
         jcr:primaryType: hee:warningCalloutReference
         /hee:warningCalloutContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: cabc00bf-bd7f-4d0f-89e3-920fa0729bf1
-      /hee:contentBlocks[23]:
+      /hee:contentBlocks[22]:
         jcr:primaryType: hee:statementCardReference
         /hee:statementCardContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: 9a99e45b-2ab1-4c15-a23a-93ee0bb7b1ed
-      /hee:contentBlocks[24]:
+      /hee:contentBlocks[23]:
         jcr:primaryType: hee:statementCardReference
         /hee:statementCardContentBlock:
           jcr:primaryType: hippo:mirror
@@ -899,7 +899,7 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
-      /hee:contentBlocks[25]:
+      /hee:contentBlocks[24]:
         jcr:primaryType: hee:appliesToBoxReference
         /hee:appliesToBoxReference:
           jcr:primaryType: hippo:mirror
@@ -907,11 +907,11 @@
         /hee:appliesToContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: ec2ddf5d-136e-4006-bc89-c9e1cee4e98f
-      /hee:contentBlocks[26]:
+      /hee:contentBlocks[25]:
         jcr:primaryType: hee:anchorLinks
         hee:targetHeadings: [h2]
         hee:title: On this page123
-      /hee:contentBlocks[27]:
+      /hee:contentBlocks[26]:
         jcr:primaryType: hee:navMap
         hee:mapEducation: dental
         hee:title: Dental Test
@@ -1379,22 +1379,22 @@
         /hee:buttonContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: 335a1882-5d19-4e01-a557-97c7da9225e6
-      /hee:contentBlocks[21]:
+      /hee:contentBlocks[20]:
         jcr:primaryType: hee:warningCalloutReference
         /hee:warningCalloutContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: a5d0aec9-f46e-4505-9c17-7fc6bf27403f
-      /hee:contentBlocks[22]:
+      /hee:contentBlocks[21]:
         jcr:primaryType: hee:warningCalloutReference
         /hee:warningCalloutContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: cabc00bf-bd7f-4d0f-89e3-920fa0729bf1
-      /hee:contentBlocks[23]:
+      /hee:contentBlocks[22]:
         jcr:primaryType: hee:statementCardReference
         /hee:statementCardContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: 9a99e45b-2ab1-4c15-a23a-93ee0bb7b1ed
-      /hee:contentBlocks[24]:
+      /hee:contentBlocks[23]:
         jcr:primaryType: hee:statementCardReference
         /hee:statementCardContentBlock:
           jcr:primaryType: hippo:mirror
@@ -1405,7 +1405,7 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
-      /hee:contentBlocks[25]:
+      /hee:contentBlocks[24]:
         jcr:primaryType: hee:appliesToBoxReference
         /hee:appliesToBoxReference:
           jcr:primaryType: hippo:mirror
@@ -1413,11 +1413,11 @@
         /hee:appliesToContentBlock:
           jcr:primaryType: hippo:mirror
           hippo:docbase: ec2ddf5d-136e-4006-bc89-c9e1cee4e98f
-      /hee:contentBlocks[26]:
+      /hee:contentBlocks[25]:
         jcr:primaryType: hee:anchorLinks
         hee:targetHeadings: [h2]
         hee:title: On this page123
-      /hee:contentBlocks[27]:
+      /hee:contentBlocks[26]:
         jcr:primaryType: hee:navMap
         hee:mapEducation: dental
         hee:title: Dental Test
@@ -2710,7 +2710,7 @@
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
     jcr:uuid: e6860730-ce03-4923-87c6-ec3eb4afc5b4
     hippo:name: Welcome
-    hippo:versionHistory: 55f78dc1-36cc-48a5-afa4-be986edd054e
+    hippo:versionHistory: 037cd892-ae9a-4289-9d82-5b84cf1ff452
     /welcome[1]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:referenceable']
@@ -2724,7 +2724,7 @@
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2022-05-23T17:47:45.428+01:00
-      hippostdpubwf:lastModificationDate: 2022-05-23T17:47:45.428+01:00
+      hippostdpubwf:lastModificationDate: 2023-02-14T11:55:43.507Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 4e544395-8d19-4c37-b02e-d07ed6e9324f
       hippotranslation:locale: en
@@ -2745,7 +2745,7 @@
       /hee:logoGroup:
         jcr:primaryType: hippo:mirror
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
-      /hee:rightHandBlocks:
+      /hee:rightHandBlocks[1]:
         jcr:primaryType: hee:ctaCardReference
         /hee:ctaCardContentBlock:
           jcr:primaryType: hippo:mirror
@@ -2756,6 +2756,21 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
+      /hee:rightHandBlocks[2]:
+        jcr:primaryType: hee:contactCardWithDescriptionReference
+        /hee:contactCardWithDescription:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 8a27aa67-f44b-4a98-9550-5a94a9c0edf2
+      /hee:rightHandBlocks[3]:
+        jcr:primaryType: hee:contactCardReference
+        /hee:content:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
+      /hee:rightHandBlocks[4]:
+        jcr:primaryType: hee:contactCardWithDescriptionReference
+        /hee:contactCardWithDescription:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 247dd9b4-9039-47b3-b003-7945d28471ac
     /welcome[2]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
@@ -2769,7 +2784,7 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2022-05-23T17:47:45.428+01:00
-      hippostdpubwf:lastModificationDate: 2022-05-23T17:49:23.398+01:00
+      hippostdpubwf:lastModificationDate: 2023-02-15T15:25:04.412Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 4e544395-8d19-4c37-b02e-d07ed6e9324f
       hippotranslation:locale: en
@@ -2790,7 +2805,7 @@
       /hee:logoGroup:
         jcr:primaryType: hippo:mirror
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
-      /hee:rightHandBlocks:
+      /hee:rightHandBlocks[1]:
         jcr:primaryType: hee:ctaCardReference
         /hee:ctaCardContentBlock:
           jcr:primaryType: hippo:mirror
@@ -2801,6 +2816,21 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
+      /hee:rightHandBlocks[2]:
+        jcr:primaryType: hee:contactCardWithDescriptionReference
+        /hee:contactCardWithDescription:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 8a27aa67-f44b-4a98-9550-5a94a9c0edf2
+      /hee:rightHandBlocks[3]:
+        jcr:primaryType: hee:contactCardReference
+        /hee:content:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
+      /hee:rightHandBlocks[4]:
+        jcr:primaryType: hee:contactCardWithDescriptionReference
+        /hee:contactCardWithDescription:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 247dd9b4-9039-47b3-b003-7945d28471ac
     /welcome[3]:
       jcr:primaryType: hee:guidance
       jcr:mixinTypes: ['mix:referenceable']
@@ -2814,9 +2844,9 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2022-05-23T17:47:45.428+01:00
-      hippostdpubwf:lastModificationDate: 2022-05-23T17:49:23.398+01:00
+      hippostdpubwf:lastModificationDate: 2023-02-15T15:25:04.412Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2022-05-23T17:49:38.085+01:00
+      hippostdpubwf:publicationDate: 2023-02-15T15:25:06.435Z
       hippotranslation:id: 4e544395-8d19-4c37-b02e-d07ed6e9324f
       hippotranslation:locale: en
       /hee:relatedContent:
@@ -2836,7 +2866,7 @@
       /hee:logoGroup:
         jcr:primaryType: hippo:mirror
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
-      /hee:rightHandBlocks:
+      /hee:rightHandBlocks[1]:
         jcr:primaryType: hee:ctaCardReference
         /hee:ctaCardContentBlock:
           jcr:primaryType: hippo:mirror
@@ -2847,3 +2877,18 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
+      /hee:rightHandBlocks[2]:
+        jcr:primaryType: hee:contactCardWithDescriptionReference
+        /hee:contactCardWithDescription:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 8a27aa67-f44b-4a98-9550-5a94a9c0edf2
+      /hee:rightHandBlocks[3]:
+        jcr:primaryType: hee:contactCardReference
+        /hee:content:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 507b8b28-dbf0-4799-a9ce-20ae57ed5b3e
+      /hee:rightHandBlocks[4]:
+        jcr:primaryType: hee:contactCardWithDescriptionReference
+        /hee:contactCardWithDescription:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 247dd9b4-9039-47b3-b003-7945d28471ac

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
@@ -121,6 +121,9 @@
                             <#case "uk.nhs.hee.web.beans.ContactCardReference">
                                 <@hee.contactCard contact=block.content/>
                                 <#break>
+                            <#case "uk.nhs.hee.web.beans.ContactCardWithDescriptionReference">
+                                <@hee.contactCardWithDescription contactWithDescription=block.contactCardWithDescription/>
+                                <#break>
                             <#case "uk.nhs.hee.web.beans.ExternalLinksCardReference">
                                 <@hee.externalLinksCard card=block.externalLinksCard/>
                                 <#break>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/news-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/news-main.ftl
@@ -125,6 +125,9 @@
                                     <#case "uk.nhs.hee.web.beans.ContactCardReference">
                                         <@hee.contactCard contact=block.content/>
                                         <#break>
+                                    <#case "uk.nhs.hee.web.beans.ContactCardWithDescriptionReference">
+                                        <@hee.contactCardWithDescription contactWithDescription=block.contactCardWithDescription/>
+                                        <#break>
                                     <#case "uk.nhs.hee.web.beans.ExternalLinksCardReference">
                                         <@hee.externalLinksCard card=block.externalLinksCard/>
                                         <#break>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/components.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/components.ftl
@@ -1,5 +1,6 @@
 <#include "action-link.ftl">
 <#include "contact-card.ftl">
+<#include "contact-card-with-description.ftl">
 <#include "contact.ftl">
 <#include "content-cards.ftl">
 <#include "external-links-card.ftl">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/contact-card-with-description.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/contact-card-with-description.ftl
@@ -1,0 +1,15 @@
+<#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
+<#assign fmt=JspTaglibs ["http://java.sun.com/jsp/jstl/fmt"] >
+
+<#import "contact-card.ftl" as contactCard>
+
+<#macro contactCardWithDescription contactWithDescription>
+    <#if contactWithDescription??>
+        <#if contactWithDescription.contactCardReference??>
+            <#if contactWithDescription.contactCardReference.content??>
+                <#assign description='${(contactWithDescription.description)!""}'/>
+                <@contactCard.contactCard contact=contactWithDescription.contactCardReference.content description=description/>
+            </#if>
+        </#if>
+    </#if>
+</#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/contact-card.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/contact-card.ftl
@@ -4,13 +4,13 @@
 <#import "person-contact.ftl" as personContact>
 <#import "department-contact.ftl" as departmentContact>
 
-<#macro contactCard contact>
+<#macro contactCard contact description="">
     <#if contact??>
         <div class="nhsuk-contact nhsuk-contact__card">
             <#if hst.isBeanType(contact, 'uk.nhs.hee.web.beans.Person')>
-                <@personContact.personContact person=contact/>
+                <@personContact.personContact person=contact description=description/>
             <#elseif hst.isBeanType(contact, 'uk.nhs.hee.web.beans.Department')>
-                <@departmentContact.departmentContact department=contact/>
+                <@departmentContact.departmentContact department=contact description=description/>
             </#if>
         </div>
     </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/department-contact.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/department-contact.ftl
@@ -1,7 +1,7 @@
 <#include "../../include/imports.ftl">
 <#include "../utils/phone-number-util.ftl">
 
-<#macro departmentContact department>
+<#macro departmentContact department description="">
     <div class="nhsuk-contact__content">
         <h3 data-anchorlinksignore="true" class="nhsuk-contact__name" aria-label="Name">${department.name}</h3>
         <#if department.organisation?has_content>
@@ -38,8 +38,8 @@
                 <p aria-label="Address">${department.address?replace('\n', '<br>')}</p>
             </#if>
 
-            <#if department.description?has_content>
-                <p class="nhsuk-u-secondary-text-color" aria-label="Description">${department.description}</p>
+            <#if description?has_content>
+                <p class="nhsuk-u-secondary-text-color" aria-label="Description">${description}</p>
             </#if>
         </div>
     </div>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
@@ -112,6 +112,9 @@
                                     <#case "uk.nhs.hee.web.beans.ContactCardReference">
                                         <@hee.contactCard contact=block.content/>
                                         <#break>
+                                    <#case "uk.nhs.hee.web.beans.ContactCardWithDescriptionReference">
+                                        <@hee.contactCardWithDescription contactWithDescription=block.contactCardWithDescription/>
+                                        <#break>
                                     <#case "uk.nhs.hee.web.beans.ExternalLinksCardReference">
                                         <@hee.externalLinksCard card=block.externalLinksCard/>
                                         <#break>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-contact.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-contact.ftl
@@ -1,7 +1,7 @@
 <#include "../../include/imports.ftl">
 <#include "../utils/phone-number-util.ftl">
 
-<#macro personContact person isAuthor=false>
+<#macro personContact person isAuthor=false description="">
     <div class="nhsuk-contact__content">
 
         <#-- Get Person Initials -->
@@ -88,8 +88,8 @@
                 <p aria-label="Address">${person.address?replace('\n', '<br>')}</p>
             </#if>
 
-            <#if person.bio?has_content>
-                <p class="nhsuk-u-secondary-text-color" aria-label="Description">${person.bio}</p>
+            <#if description?has_content>
+                <p class="nhsuk-u-secondary-text-color" aria-label="Description">${description}</p>
             </#if>
         </div>
     </div>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/ContactCardWithDescription.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/ContactCardWithDescription.java
@@ -1,0 +1,19 @@
+package uk.nhs.hee.web.beans;
+
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.Node;
+import uk.nhs.hee.web.beans.ContactCardReference;
+
+@HippoEssentialsGenerated(internalName = "hee:contactCardWithDescription")
+@Node(jcrType = "hee:contactCardWithDescription")
+public class ContactCardWithDescription extends BaseDocument {
+    @HippoEssentialsGenerated(internalName = "hee:description")
+    public String getDescription() {
+        return getSingleProperty("hee:description");
+    }
+
+    @HippoEssentialsGenerated(internalName = "hee:contactCardReference")
+    public ContactCardReference getContactCardReference() {
+        return getBean("hee:contactCardReference", ContactCardReference.class);
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/ContactCardWithDescriptionReference.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/ContactCardWithDescriptionReference.java
@@ -1,0 +1,15 @@
+package uk.nhs.hee.web.beans;
+
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+
+@HippoEssentialsGenerated(internalName = "hee:contactCardWithDescriptionReference")
+@Node(jcrType = "hee:contactCardWithDescriptionReference")
+public class ContactCardWithDescriptionReference extends HippoCompound {
+    @HippoEssentialsGenerated(internalName = "hee:contactCardWithDescription")
+    public HippoBean getContactCardWithDescription() {
+        return getLinkedBean("hee:contactCardWithDescription", HippoBean.class);
+    }
+}


### PR DESCRIPTION
Rename old contact card to Card - Contact (Old)
Added new contact card Card - Contact which contains description field and selected contact

Modified Blog post, Home, News article and Standard content pages by removing ability to add "Contact - Card (Old)" types and only allow "Contact - Card" in RHS for Blog, News article and Standard content

Note: All templates still display previously created "Contact - Card (Old)" content, if present, but will not allow new instances to be added (must be "Contact - Card" ony, where applicable)