### PR TITLE
[NWPS-1346] Publication landing page validator and workflow updates

### DIFF
--- a/cms/src/main/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperation.java
+++ b/cms/src/main/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperation.java
@@ -9,11 +9,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Author ({@code hee:author}) document workflow implementation which is essentially an extension of default
- * {@link DocumentWorkflowImpl}, but removes {@code copy} operation in order not to allow Editors
- * to copy Author documents.
+ * An extension of OOTB default {@link DocumentWorkflowImpl} which essentially removes {@code copy} operation
+ * in order not to allow content editors to copy documents of certain types (e.g. Author {@code hee:author}, etc.).
  */
-public class AuthorDocumentWorkflowImpl extends DocumentWorkflowImpl {
+public class DocumentWorkflowImplWithoutCopyOperation extends DocumentWorkflowImpl {
     private static final long serialVersionUID = -2096611300462592784L;
 
 
@@ -22,7 +21,7 @@ public class AuthorDocumentWorkflowImpl extends DocumentWorkflowImpl {
      *
      * @throws RemoteException mandatory exception that must be thrown by all Remote objects
      */
-    public AuthorDocumentWorkflowImpl() throws RemoteException {
+    public DocumentWorkflowImplWithoutCopyOperation() throws RemoteException {
         // To handle 'java.rmi.RemoteException' matching
         // 'org.onehippo.repository.documentworkflow.DocumentWorkflowImpl.DocumentWorkflowImpl' super class constructor.
     }

--- a/cms/src/test/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperationTest.java
+++ b/cms/src/test/java/uk/nhs/hee/web/repository/documentworkflow/DocumentWorkflowImplWithoutCopyOperationTest.java
@@ -19,23 +19,25 @@ import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"javax.management.*", "javax.script.*"})
-@PrepareForTest({ AuthorDocumentWorkflowImpl.class })
-public class AuthorDocumentWorkflowImplTest {
+@PrepareForTest({DocumentWorkflowImplWithoutCopyOperation.class})
+public class DocumentWorkflowImplWithoutCopyOperationTest {
 
-    private final HashMap<String, Serializable> originalHints = new HashMap<String, Serializable>(){
+    private final HashMap<String, Serializable> originalHints = new HashMap<String, Serializable>() {
         private static final long serialVersionUID = -2936036450308608383L;
+
         {
             put("delete", "true");
             put("copy", "true");
             put("publish", "true");
             put("depublish", "false");
-        }};
+        }
+    };
 
-    private AuthorDocumentWorkflowImpl systemUnderTest;
+    private DocumentWorkflowImplWithoutCopyOperation systemUnderTest;
 
     @Before
     public void setUp() throws Exception {
-        systemUnderTest = spy(new AuthorDocumentWorkflowImpl());
+        systemUnderTest = spy(new DocumentWorkflowImplWithoutCopyOperation());
     }
 
     @Test

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
@@ -30,3 +30,5 @@ definitions:
         already exists as a Web publication for another Publication landing page document
         in the CMS. A Publication page cannot be multiple Web publications. Please
         select a different Publication page.'
+      hee:unique-web-publications-validator#duplicate-publication-pages: Please remove
+        duplicate Publication page document(s)

--- a/repository-data/application/src/main/resources/hcm-config/configuration/workflows/default.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/workflows/default.yaml
@@ -3,11 +3,58 @@ definitions:
     /hippo:configuration/hippo:workflows/default/authorHandle:
       .meta:order-before: handle
       jcr:primaryType: frontend:workflow
-      hipposys:classname: uk.nhs.hee.web.repository.documentworkflow.AuthorDocumentWorkflowImpl
-      hipposys:display: Author handle workflow
+      hipposys:classname: uk.nhs.hee.web.repository.documentworkflow.DocumentWorkflowImplWithoutCopyOperation
+      hipposys:display: Author document handle workflow
       hipposys:nodetype: hippo:handle
       hipposys:privileges: ['hippo:author']
       hipposys:subtype: hee:author
+      /hipposys:config:
+        jcr:primaryType: nt:unstructured
+        scxml-definition: documentworkflow
+      /frontend:renderer:
+        jcr:primaryType: frontend:plugincluster
+        frontend:references: [browser.id, editor.id, wicket.model]
+        frontend:services: [wicket.id]
+        item: ${cluster.id}.item
+        /root:
+          jcr:primaryType: frontend:plugin
+          plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+        /admin:
+          jcr:primaryType: frontend:plugin
+          plugin.class: org.hippoecm.frontend.plugins.reviewedactions.AdminWorkflowPlugin
+          wicket.id: ${item}
+        /publication:
+          jcr:primaryType: frontend:plugin
+          plugin.class: org.hippoecm.frontend.plugins.reviewedactions.PublicationWorkflowPlugin
+          wicket.id: ${item}
+        /document:
+          jcr:primaryType: frontend:plugin
+          plugin.class: org.hippoecm.frontend.plugins.reviewedactions.DocumentWorkflowPlugin
+          wicket.id: ${item}
+        /top:
+          jcr:primaryType: frontend:plugin
+          plugin.class: org.hippoecm.frontend.plugins.reviewedactions.PreviewWorkflowPlugin
+          wicket.id: ${item}
+        /requests:
+          jcr:primaryType: frontend:plugin
+          plugin.class: org.hippoecm.frontend.plugins.reviewedactions.RequestsWorkflowPlugin
+          wicket.id: ${item}
+        /metadata:
+          jcr:primaryType: frontend:plugin
+          plugin.class: org.hippoecm.frontend.plugins.reviewedactions.DocMetaDataPlugin
+          wicket.id: ${item}
+        /channelactions:
+          jcr:primaryType: frontend:plugin
+          plugin.class: org.onehippo.cms7.channelmanager.plugins.channelactions.ChannelActionsPlugin
+          wicket.id: ${item}
+    /hippo:configuration/hippo:workflows/default/publicationLandingPageHandle:
+      .meta:order-before: handle
+      jcr:primaryType: frontend:workflow
+      hipposys:classname: uk.nhs.hee.web.repository.documentworkflow.DocumentWorkflowImplWithoutCopyOperation
+      hipposys:display: Publication landing page document handle workflow
+      hipposys:nodetype: hippo:handle
+      hipposys:privileges: ['hippo:author']
+      hipposys:subtype: hee:publicationLandingPage
       /hipposys:config:
         jcr:primaryType: nt:unstructured
         scxml-definition: documentworkflow


### PR DESCRIPTION
- `UniqueWebPublicationsValidator` has been updated to raise a duplicate `Publication page` error in case the same `Publication page` document has been associated with a `Publication landing page` document multiple times (via `Publication pages` field).
- `/hippo:configuration/hippo:workflows/default/publicationLandingPageHandle` workflow has been added for `Publication landing page` document type in order to remove the `Copy...` operation so as to restrict content editors from copying `Publication landing page` documents.