### PR TITLE
[NWPS-1292] CKEditor enhancements

### DIFF
--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -86,6 +86,28 @@
         <groupId>org.onehippo.cms.l10n</groupId>
         <artifactId>hippo-cms-l10n-maven-plugin</artifactId>
       </plugin>
+      <!-- Creates optimised version of the CKEditor resources under 'ckeditor/optimized' directory -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-optimized-ckeditor-resources</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/classes/ckeditor/optimized</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/src/main/resources/ckeditor</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/cms/src/main/resources/ckeditor/custom_styles.js
+++ b/cms/src/main/resources/ckeditor/custom_styles.js
@@ -1,0 +1,20 @@
+/*
+ * Overrides default style set for 'stylescombo' plugin
+ * in order to remove 'Heading 1' ({ name: 'Heading 1', element: 'h1' })
+ * from the Styles dropdown.
+ */
+(function () {
+  "use strict";
+
+  CKEDITOR.stylesSet.add('custom_styles', [
+	{ name: 'Normal',		element: 'p' },
+	{ name: 'Heading 2',		element: 'h2' },
+	{ name: 'Heading 3',		element: 'h3' },
+	{ name: 'Heading 4',		element: 'h4' },
+	{ name: 'Heading 5',		element: 'h5' },
+	{ name: 'Heading 6',		element: 'h6' },
+	{ name: 'Preformatted Text',element: 'pre' },
+	{ name: 'Address',			element: 'address' }
+  ]);
+
+}());

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/AfterForm.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/AfterForm.yaml
@@ -86,6 +86,7 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'
           /backLink:
             jcr:primaryType: frontend:plugin
             caption: Back link

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/Inset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/Inset.yaml
@@ -61,3 +61,4 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/StatementBlock.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/StatementBlock.yaml
@@ -70,3 +70,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/banner.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/banner.yaml
@@ -84,6 +84,6 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              ckeditor.config.appended.json: '{removeButtons: "Underline,Strike,Subscript,Superscript,Anchor,FontSize,Font,Styles", extraPlugins: "format"}'
+              ckeditor.config.appended.json: '{removeButtons: "Underline,Strike,Subscript,Superscript,Anchor,FontSize,Font,Styles", extraPlugins: "format", forcePasteAsPlainText: true}'
               ckeditor.config.overlayed.json: '{toolbarGroups: [{name: "styles"},
                 {name: "basicstyles"}, {name: "links"}], format_tags: "p;h2;h3", allowedContent: true, forcePasteAsPlainText: true}'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blockLinks.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blockLinks.yaml
@@ -102,6 +102,7 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'
           /blockLinks:
             jcr:primaryType: frontend:plugin
             caption: Block links

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/details.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/details.yaml
@@ -79,4 +79,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              ckeditor.config.appended.json: '{ removeButtons: "PickImage" }'
+              ckeditor.config.appended.json: '{ removeButtons: "PickImage", forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/expanderPanel.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/expanderPanel.yaml
@@ -69,4 +69,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              ckeditor.config.appended.json: '{ removeButtons: "PickImage" }'
+              ckeditor.config.appended.json: '{ removeButtons: "PickImage", forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/mediaEmbed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/mediaEmbed.yaml
@@ -166,6 +166,7 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'
           /mediaLastNextReview:
             jcr:primaryType: frontend:plugin
             caption: Media review dates

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/navMap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/navMap.yaml
@@ -117,6 +117,7 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'
           /mapEducation:
             jcr:primaryType: frontend:plugin
             caption: Map Education

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/newsletterSubscribeForm.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/newsletterSubscribeForm.yaml
@@ -193,6 +193,7 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'
           /successUrl:
             jcr:primaryType: frontend:plugin
             caption: Success url

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/richTextBlock.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/richTextBlock.yaml
@@ -61,3 +61,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: false }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/statementCard.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/statementCard.yaml
@@ -79,3 +79,4 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/tabPanel.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/tabPanel.yaml
@@ -70,3 +70,4 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               ckeditor.config.appended.json: ''
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/table.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/table.yaml
@@ -81,4 +81,4 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
               ckeditor.config.appended.json: '{ removeButtons: "PickImage", removePlugins:
                 "basicstyles,justify,list,stylescombo,youtube,copyformatting,removeformat,indentblock,indentlist,indent"}'
-              ckeditor.config.overlayed.json: ''
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/warningCallout.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/warningCallout.yaml
@@ -79,3 +79,4 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hippostd/html.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hippostd/html.yaml
@@ -1,6 +1,7 @@
 definitions:
   config:
     /hippo:namespaces/hippostd/html/editor:templates/_default_:
-      ckeditor.config.appended.json: '{ removeButtons: "PickImage,Table" }'
+      ckeditor.config.appended.json: '{ removeButtons: "PickImage,Table", stylesSet:
+        "custom_styles:./custom_styles.js" }'
       ckeditor.config.overlayed.json: '{ allowedContent: true, forcePasteAsPlainText:
-        true }'
+        false }'


### PR DESCRIPTION
- Custom `styleSet` impl. for CKEditor to remove `Heading 1` from `Styles` dropdown.
- Reverting `forcePasteAsPlainText=true` for `hippostd:html` and `hee:richTextBlock` document types.