### PR TITLE
[NWPS-1257] Search now correctly finding only content on published pages

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/listing.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/labels/listing.yaml
@@ -4,7 +4,7 @@
   jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
   jcr:uuid: 03cc6eaf-ca38-4874-a8a5-22ae5ea2c643
   hippo:name: Listing
-  hippo:versionHistory: 4deefde3-8bbc-428b-a73b-92b3958dd089
+  hippo:versionHistory: c2a221ab-513c-4d48-8217-e91e1017fc89
   /listing[1]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -14,12 +14,13 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-24T17:37:06.731Z
-    hippostdpubwf:lastModificationDate: 2022-11-27T20:11:13.675Z
+    hippostdpubwf:lastModificationDate: 2023-03-08T08:01:52.214Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: [Used in a Bulletin component to show a bulletin
         item overview., Used in a Bulletin component to show a bulletin item website.,
       '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+      '']
     resourcebundle:id: uk.nhs.hee.web.listing
     resourcebundle:keys: [bulletin.overview, bulletin.website, sort.label, sort.option.oldest,
       sort.option.newest, filter.category.label, filters.label, filter.content_type.label,
@@ -30,14 +31,14 @@
       filter.year.label, event.date, event.location, casestudy.impact_group, casestudy.impact_types,
       searchbank.key_terms, sort.option.az, casestudy.provider, casestudy.submitted_date,
       sort.option.submitted_date_newest, sort.option.submitted_date_oldest, publication.type,
-      publication.topic, publication.profession, publication.publish_date]
+      publication.topic, publication.profession, publication.publish_date, result.count.text]
     resourcebundle:messages: [Overview, Website, Sort by, Oldest, Newest, Category,
       Filters, Content type, Date, results, Published on, By, Sector, Region, Topic,
       Topics, Strings / Strategies, Get Strategy, Search, Get Search, Completed on,
       Provider, Category, Document, Get Document, Year, Date, Location, Group Impacted,
       Impact Types, Key Terms, A to Z, Organisation, Date Submitted, Date Submitted
         - Newest, Date Submitted - Oldest, Publication type, Topic, Profession, Publish
-        date]
+        date, result]
   /listing[2]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
@@ -47,12 +48,13 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-24T17:37:06.731Z
-    hippostdpubwf:lastModificationDate: 2022-11-27T20:11:31.192Z
+    hippostdpubwf:lastModificationDate: 2023-03-08T08:02:31.460Z
     hippostdpubwf:lastModifiedBy: admin
     resourcebundle:descriptions: [Used in a Bulletin component to show a bulletin
         item overview., Used in a Bulletin component to show a bulletin item website.,
       '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+      '']
     resourcebundle:id: uk.nhs.hee.web.listing
     resourcebundle:keys: [bulletin.overview, bulletin.website, sort.label, sort.option.oldest,
       sort.option.newest, filter.category.label, filters.label, filter.content_type.label,
@@ -63,14 +65,14 @@
       filter.year.label, event.date, event.location, casestudy.impact_group, casestudy.impact_types,
       searchbank.key_terms, sort.option.az, casestudy.provider, casestudy.submitted_date,
       sort.option.submitted_date_newest, sort.option.submitted_date_oldest, publication.type,
-      publication.topic, publication.profession, publication.publish_date]
+      publication.topic, publication.profession, publication.publish_date, result.count.text]
     resourcebundle:messages: [Overview, Website, Sort by, Oldest, Newest, Category,
       Filters, Content type, Date, results, Published on, By, Sector, Region, Topic,
       Topics, Strings / Strategies, Get Strategy, Search, Get Search, Completed on,
       Provider, Category, Document, Get Document, Year, Date, Location, Group Impacted,
       Impact Types, Key Terms, A to Z, Organisation, Date Submitted, Date Submitted
         - Newest, Date Submitted - Oldest, Publication type, Topic, Profession, Publish
-        date]
+        date, result]
   /listing[3]:
     jcr:primaryType: resourcebundle:resourcebundle
     jcr:mixinTypes: ['mix:referenceable']
@@ -80,13 +82,14 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2021-02-24T17:37:06.731Z
-    hippostdpubwf:lastModificationDate: 2022-11-27T20:11:31.192Z
+    hippostdpubwf:lastModificationDate: 2023-03-08T08:02:31.460Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2022-11-27T20:11:32.898Z
+    hippostdpubwf:publicationDate: 2023-03-08T08:06:44.810Z
     resourcebundle:descriptions: [Used in a Bulletin component to show a bulletin
         item overview., Used in a Bulletin component to show a bulletin item website.,
       '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']
+      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+      '']
     resourcebundle:id: uk.nhs.hee.web.listing
     resourcebundle:keys: [bulletin.overview, bulletin.website, sort.label, sort.option.oldest,
       sort.option.newest, filter.category.label, filters.label, filter.content_type.label,
@@ -97,11 +100,11 @@
       filter.year.label, event.date, event.location, casestudy.impact_group, casestudy.impact_types,
       searchbank.key_terms, sort.option.az, casestudy.provider, casestudy.submitted_date,
       sort.option.submitted_date_newest, sort.option.submitted_date_oldest, publication.type,
-      publication.topic, publication.profession, publication.publish_date]
+      publication.topic, publication.profession, publication.publish_date, result.count.text]
     resourcebundle:messages: [Overview, Website, Sort by, Oldest, Newest, Category,
       Filters, Content type, Date, results, Published on, By, Sector, Region, Topic,
       Topics, Strings / Strategies, Get Strategy, Search, Get Search, Completed on,
       Provider, Category, Document, Get Document, Year, Date, Location, Group Impacted,
       Impact Types, Key Terms, A to Z, Organisation, Date Submitted, Date Submitted
         - Newest, Date Submitted - Oldest, Publication type, Topic, Profession, Publish
-        date]
+        date, result]

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchresults-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/searchresults-main.ftl
@@ -42,7 +42,11 @@
                     <div class="nhsuk-listing__list nhsuk-grid-column-two-thirds">
                         <div class="nhsuk-listing__summary o-flex@tablet">
                             <#-- Results number -->
-                            <@fmt.message key="results.count.text" var="resultsCountText"/>
+                            <#if pageable.total=1>
+                                <@fmt.message key="result.count.text" var="resultsCountText"/>
+                            <#else>
+                                <@fmt.message key="results.count.text" var="resultsCountText"/>
+                            </#if>
                             <h2 class="nhsuk-listing__title nhsuk-heading-l o-flex__grow">
                                 ${pageable.total} ${resultsCountText}
                             </h2>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
@@ -277,92 +277,88 @@
 </#macro>
 
 <#macro searchListItem items>
-    <@hst.link var="pageNotFoundURL" siteMapItemRefId="pagenotfound"/>
-
     <#list items as item>
-        <#assign pageURL=getInternalLinkURL(item)>
-
-        <#if ['Bulletin', 'CaseStudy', 'SearchBank', 'Event']?seq_contains(item.class.simpleName) || pageURL != pageNotFoundURL>
-            <li>
-                <#switch item.getClass().getName()>
-                    <#case "uk.nhs.hee.web.beans.Event">
-                        <h3><a href="${item.link}">${item.title}</a></h3>
-                        <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.description!}</p>
-                        <dl class="nhsuk-summary-list">
-                            <@fmt.message key="event.date" var="dateLabel"/>
-                            <@listItemRow key="${dateLabel}">
-                                ${item.date.time?string['dd MMMM yyyy']}
-                            </@listItemRow>
-                            <@fmt.message key="event.location" var="locationLabel"/>
-                            <@listItemRow key="${locationLabel}">
-                                ${item.location}
-                            </@listItemRow>
-                        </dl>
+        <li>
+            <#switch item.getClass().getName()>
+                <#case "uk.nhs.hee.web.beans.Event">
+                    <h3><a href="${item.link}">${item.title}</a></h3>
+                    <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.description!}</p>
+                    <dl class="nhsuk-summary-list">
+                        <@fmt.message key="event.date" var="dateLabel"/>
+                        <@listItemRow key="${dateLabel}">
+                            ${item.date.time?string['dd MMMM yyyy']}
+                        </@listItemRow>
+                        <@fmt.message key="event.location" var="locationLabel"/>
+                        <@listItemRow key="${locationLabel}">
+                            ${item.location}
+                        </@listItemRow>
+                    </dl>
+                    <p class="nhsuk-body-s">
+                        <@fmt.message key="published_on.text"/> ${item.publishedDate}
+                    </p>
+                    <#break>
+                <#case "uk.nhs.hee.web.beans.CaseStudy">
+                    <@hst.link var="caseStudyDocumentURL" hippobean=item.document>
+                        <@hst.param name="forceDownload" value="true"/>
+                    </@hst.link>
+                    <h3><a href="${caseStudyDocumentURL}" target="_blank">${item.title}</a></h3>
+                    <div class="nhsuk-review-date">
                         <p class="nhsuk-body-s">
                             <@fmt.message key="published_on.text"/> ${item.publishedDate}
                         </p>
-                        <#break>
-                    <#case "uk.nhs.hee.web.beans.CaseStudy">
-                        <@hst.link var="caseStudyDocumentURL" hippobean=item.document>
+                    </div>
+                    <#break>
+                <#case "uk.nhs.hee.web.beans.Bulletin">
+                    <h3><a href="${item.websiteUrl}">${item.title}</a></h3>
+                    <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.overview!}</p>
+                    <#break>
+                <#case "uk.nhs.hee.web.beans.SearchBank">
+                    <#if item.searchDocument?? && item.searchDocument.mimeType != 'application/vnd.hippo.blank'>
+                        <@hst.link var="searchDocumentURL" hippobean=item.searchDocument>
                             <@hst.param name="forceDownload" value="true"/>
                         </@hst.link>
-                        <h3><a href="${caseStudyDocumentURL}" target="_blank">${item.title}</a></h3>
-                        <div class="nhsuk-review-date">
-                            <p class="nhsuk-body-s">
-                                <@fmt.message key="published_on.text"/> ${item.publishedDate}
-                            </p>
-                        </div>
-                        <#break>
-                    <#case "uk.nhs.hee.web.beans.Bulletin">
-                        <h3><a href="${item.websiteUrl}">${item.title}</a></h3>
-                        <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.overview!}</p>
-                        <#break>
-                    <#case "uk.nhs.hee.web.beans.SearchBank">
-                        <#if item.searchDocument?? && item.searchDocument.mimeType != 'application/vnd.hippo.blank'>
-                            <@hst.link var="searchDocumentURL" hippobean=item.searchDocument>
-                                <@hst.param name="forceDownload" value="true"/>
-                            </@hst.link>
-                            <h3><a href="${searchDocumentURL}">${item.title}</a></h3>
+                        <h3><a href="${searchDocumentURL}">${item.title}</a></h3>
 
-                            <#assign isStrategyDocumentAvailable=(item.strategyDocument?? && item.strategyDocument.mimeType != 'application/vnd.hippo.blank')?then(true, false)>
-                            <#if isStrategyDocumentAvailable || item.completedDate??>
-                                <dl class="nhsuk-summary-list">
-                                    <#if isStrategyDocumentAvailable>
-                                        <@hst.link var="strategyDocumentURL" hippobean=item.strategyDocument>
-                                            <@hst.param name="forceDownload" value="true"/>
-                                        </@hst.link>
-                                        <@fmt.message key="searchbank.strategies" var="strategiesLabel"/>
-                                        <@listItemRow key="${strategiesLabel}">
-                                            <a href="${strategyDocumentURL}" target="_blank"><@fmt.message key="searchbank.get_strategy"/></a>
-                                        </@listItemRow>
-                                    </#if>
+                        <#assign isStrategyDocumentAvailable=(item.strategyDocument?? && item.strategyDocument.mimeType != 'application/vnd.hippo.blank')?then(true, false)>
+                        <#if isStrategyDocumentAvailable || item.completedDate??>
+                            <dl class="nhsuk-summary-list">
+                                <#if isStrategyDocumentAvailable>
+                                    <@hst.link var="strategyDocumentURL" hippobean=item.strategyDocument>
+                                        <@hst.param name="forceDownload" value="true"/>
+                                    </@hst.link>
+                                    <@fmt.message key="searchbank.strategies" var="strategiesLabel"/>
+                                    <@listItemRow key="${strategiesLabel}">
+                                        <a href="${strategyDocumentURL}" target="_blank"><@fmt.message key="searchbank.get_strategy"/></a>
+                                    </@listItemRow>
+                                </#if>
 
-                                    <#if item.completedDate??>
-                                        <@fmt.message key="searchbank.completed_on" var="completedOnLabel"/>
-                                        <@listItemRow key="${completedOnLabel}">
-                                            ${item.completedDate.time?string['dd MMMM yyyy']}
-                                        </@listItemRow>
-                                    </#if>
-                                </dl>
-                            </#if>
-                            <div class="nhsuk-review-date">
-                                <p class="nhsuk-body-s">
-                                    <@fmt.message key="published_on.text"/> ${item.publishedDate}
-                                </p>
-                            </div>
+                                <#if item.completedDate??>
+                                    <@fmt.message key="searchbank.completed_on" var="completedOnLabel"/>
+                                    <@listItemRow key="${completedOnLabel}">
+                                        ${item.completedDate.time?string['dd MMMM yyyy']}
+                                    </@listItemRow>
+                                </#if>
+                            </dl>
                         </#if>
-                        <#break>
-                    <#default>
-                        <h3><a href="${pageURL}">${item.title}</a></h3>
-                        <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.summary!}</p>
                         <div class="nhsuk-review-date">
                             <p class="nhsuk-body-s">
                                 <@fmt.message key="published_on.text"/> ${item.publishedDate}
                             </p>
                         </div>
-                </#switch>
-            </li>
-        </#if>
+                    </#if>
+                    <#break>
+                <#default>
+                    <#assign pageURL=item.properties['derived_url']>
+
+                    <h3><a href="${pageURL}">${item.title}</a></h3>
+                    <p class="nhsuk-body-s nhsuk-u-margin-top-1">${item.summary!}</p>
+                    <div class="nhsuk-review-date">
+                        <p class="nhsuk-body-s">
+                            <@fmt.message key="published_on.text"/> ${item.publishedDate}
+                        </p>
+                    </div>
+            </#switch>
+        </li>
     </#list>
 </#macro>
 


### PR DESCRIPTION
Please can you review this as there are a few changes;-
- Removed the check for pageNotFound within the template - this was reducing the number of candidates that could be displayed
- Added that check into the ListingComponent along with checks for content type and whether content was being referenced by a mini-hub
- Calculate the URL in the ListingComponent class and pass it to the template (as a property on the beans that are being selected as candidates for display) to stop it being recalculated in the template
- changed the display of total results to take into account "1 result" and "x results"

