### PR TITLE
[NWPS-1128] Advanced search plugin added

### DIFF
--- a/cms-dependencies/pom.xml
+++ b/cms-dependencies/pom.xml
@@ -69,5 +69,14 @@
       <groupId>com.onehippo.cms7</groupId>
       <artifactId>hippo-addon-urlrewriter-module-repository</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.onehippo.cms7</groupId>
+      <artifactId>hippo-addon-advanced-search-frontend</artifactId>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>com.onehippo.cms7</groupId>
+      <artifactId>hippo-addon-advanced-search-repository</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
@@ -18,9 +18,10 @@ definitions:
     /hippo:configuration/hippo:frontend/cms/cms-advanced-search/genericFilters:
       document.type.namespaces: [hee]
       document.subtypes.included: true
+      document.type.excluded: ['hee:basedocument', 'hee:contactCard']
     /hippo:configuration/hippo:frontend/cms/cms-advanced-search/titlePropertyFilter:
       jcr:primaryType: frontend:plugin
-      filterPropertyName: myproject:title
+      filterPropertyName: hee:title
       filterPropertyType: text
       plugin.class: com.onehippo.cms7.search.frontend.filters.GenericPropertyFilterPlugin
       wicket.id: ${search.extensions}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
@@ -15,3 +15,13 @@ definitions:
       max.file.size: 10M
       plugin.class: org.hippoecm.frontend.plugins.yui.upload.validation.AssetUploadValidationPlugin
       validator.id: service.publication.document.validation
+    /hippo:configuration/hippo:frontend/cms/cms-advanced-search/genericFilters:
+      document.type.namespaces: [hee]
+      document.subtypes.included: true
+    /hippo:configuration/hippo:frontend/cms/cms-advanced-search/titlePropertyFilter:
+      jcr:primaryType: frontend:plugin
+      filterPropertyName: myproject:title
+      filterPropertyType: text
+      plugin.class: com.onehippo.cms7.search.frontend.filters.GenericPropertyFilterPlugin
+      wicket.id: ${search.extensions}
+      wicket.model: ${model.search}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
@@ -37,8 +37,4 @@ definitions:
       /en:
         jcr:primaryType: hipposys:resourcebundle
         titlePropertyFilter.propertyName: Title
-        titlePropertyFilter.title: Title Filter
-      /nl:
-        jcr:primaryType: hipposys:resourcebundle
-        titlePropertyFilter.propertyName: Titel
-        titlePropertyFilter.title: Titelfilter
+        titlePropertyFilter.title: Title filter

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
@@ -32,3 +32,13 @@ definitions:
         select a different Publication page.'
       hee:unique-web-publications-validator#duplicate-publication-pages: Please remove
         duplicate Publication page document(s)
+    /hippo:configuration/hippo:translations/hippo:cms/advanced-search-filters:
+      jcr:primaryType: hipposys:resourcebundles
+      /en:
+        jcr:primaryType: hipposys:resourcebundle
+        titlePropertyFilter.propertyName: Title
+        titlePropertyFilter.title: Title Filter
+      /nl:
+        jcr:primaryType: hipposys:resourcebundle
+        titlePropertyFilter.propertyName: Titel
+        titlePropertyFilter.title: Titelfilter


### PR DESCRIPTION
This branch includes the advanced search plugin and has been configured as follows;-
- Only the "hee" namespace is available to be searched (which means that we don't see URL rewrites, for example)
- A title filter (using the hee:title attribute) has been configured as example of a search filter. This can easily be removed by reversing the instructions found here: https://xmdocumentation.bloomreach.com/library/enterprise/enterprise-features/advanced-search/custom-search-filter.html

See the video on ticket NWPS-1128 for more information abut how these filters and search options can be used by an editorial user

THIS CAN BE MERGED AS LONG AS IT IS ONLY TARGETTED AT STAGING FOR TESTING PURPOSES