### PR TITLE
[NWPS-1127] Tagging plugin for standard content pages

### DIFF
--- a/cms-dependencies/pom.xml
+++ b/cms-dependencies/pom.xml
@@ -69,5 +69,9 @@
       <groupId>com.onehippo.cms7</groupId>
       <artifactId>hippo-addon-urlrewriter-module-repository</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-content-tagging</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/essentials/src/main/resources/taggingPlugin.xml
+++ b/essentials/src/main/resources/taggingPlugin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<installerDocument>
+    <dateAdded>2023-05-05T13:54:53.053+01:00</dateAdded>
+    <dateInstalled>2023-05-05T13:54:53.053+01:00</dateInstalled>
+    <installationState>installed</installationState>
+</installerDocument>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
@@ -20,6 +20,20 @@ definitions:
       /en:
         jcr:primaryType: hipposys:resourcebundle
         jcr:name: '[Page] Standard content page'
+        hee:tags: Keywords
+        hee:tagssupport: Keyword suggestions
+      /nl:
+        jcr:primaryType: hipposys:resourcebundle
+        hee:tags: Trefwoorden
+        hee:tagssupport: Gesuggereerde trefwoorden
+      /de:
+        jcr:primaryType: hipposys:resourcebundle
+        hee:tags: Stichworte
+        hee:tagssupport: Stichwortvorschläge
+      /fr:
+        jcr:primaryType: hipposys:resourcebundle
+        hee:tags: Mots-clés
+        hee:tagssupport: Suggestions de mots-clés
     /hippo:configuration/hippo:translations/hippo:types/hee:imagesetWithCaption:
       jcr:primaryType: hipposys:resourcebundles
       /en:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
@@ -20,20 +20,6 @@ definitions:
       /en:
         jcr:primaryType: hipposys:resourcebundle
         jcr:name: '[Page] Standard content page'
-        hee:tags: Keywords
-        hee:tagssupport: Keyword suggestions
-      /nl:
-        jcr:primaryType: hipposys:resourcebundle
-        hee:tags: Trefwoorden
-        hee:tagssupport: Gesuggereerde trefwoorden
-      /de:
-        jcr:primaryType: hipposys:resourcebundle
-        hee:tags: Stichworte
-        hee:tagssupport: Stichwortvorschläge
-      /fr:
-        jcr:primaryType: hipposys:resourcebundle
-        hee:tags: Mots-clés
-        hee:tagssupport: Suggestions de mots-clés
     /hippo:configuration/hippo:translations/hippo:types/hee:imagesetWithCaption:
       jcr:primaryType: hipposys:resourcebundles
       /en:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
@@ -13,7 +13,8 @@ definitions:
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
           jcr:uuid: bc200099-8ae9-4c22-80fa-9a92f8114a20
           hipposysedit:node: true
-          hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
+          hipposysedit:supertype: ['hippostd:taggable', 'hippotranslation:translated',
+            'hee:basedocument', 'hippostd:relaxed']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
           /title:
             jcr:primaryType: hipposysedit:field
@@ -99,7 +100,7 @@ definitions:
           hippostdpubwf:lastModifiedBy: ''
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
-          jcr:mixinTypes: ['mix:referenceable']
+          jcr:mixinTypes: ['mix:referenceable', 'hippostd:taggable']
           hee:title: ''
           hee:summary: ''
           jcr:uuid: f926f4a1-7d39-443e-92be-973020f33532
@@ -245,3 +246,31 @@ definitions:
             hint: ''
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+          /tags:
+            jcr:primaryType: frontend:plugin
+            engine: ${engine}
+            mode: ${mode}
+            plugin.class: org.onehippo.forge.ecmtagging.editor.TagsPlugin
+            search.paths: /content
+            wicket.id: ${cluster.id}.left.item
+            wicket.model: ${wicket.model}
+            widget.cols: '20'
+            widget.rows: '2'
+            /yui.config:
+              jcr:primaryType: frontend:pluginconfig
+              anim.vert: true
+              container.id: tagging-autocomplete
+              schema.fields: [label, url]
+              schema.result.list: response.results
+              use.shadow: true
+              /schema.meta.fields:
+                jcr:primaryType: frontend:pluginconfig
+                totalHits: response.totalHits
+          /tagsuggest:
+            jcr:primaryType: frontend:plugin
+            engine: ${engine}
+            mode: ${mode}
+            numberOfSuggestions: 10
+            plugin.class: org.onehippo.forge.ecmtagging.editor.TagSuggestPlugin
+            wicket.id: ${cluster.id}.left.item
+            wicket.model: ${wicket.model}

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/digital-transformation/digital-academy.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/digital-transformation/digital-academy.yaml
@@ -6,7 +6,7 @@
   hippo:versionHistory: a1ae103c-aeb4-488f-9c04-3d666b703c6e
   /digital-academy[1]:
     jcr:primaryType: hee:guidance
-    jcr:mixinTypes: ['mix:referenceable']
+    jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
     jcr:uuid: 508e8401-7fd8-441a-af7e-2747216124a1
     hee:summary: ''
     hee:title: Digital Academy
@@ -44,7 +44,7 @@
       hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
   /digital-academy[2]:
     jcr:primaryType: hee:guidance
-    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+    jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
     jcr:uuid: 754df7b5-254a-4059-8184-a6533305d36e
     hee:summary: ''
     hee:title: Digital Academy
@@ -82,7 +82,7 @@
       hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
   /digital-academy[3]:
     jcr:primaryType: hee:guidance
-    jcr:mixinTypes: ['mix:referenceable']
+    jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
     jcr:uuid: 39a3f582-54c5-41a0-8ef1-40824fddb6bf
     hee:summary: ''
     hee:title: Digital Academy

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/a-to-z-test-content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/a-to-z-test-content.yaml
@@ -14,7 +14,7 @@
     hippo:versionHistory: d01f2158-e1a3-4f57-b460-33d2aa10c579
     /apple[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 4610dd48-6404-49e5-9402-a3509a7692a1
       hee:addToAZ: false
       hee:summary: ''
@@ -53,7 +53,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /apple[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 8a50387a-5b15-48e1-8cf9-dca10818fbfc
       hee:addToAZ: false
       hee:summary: ''
@@ -92,7 +92,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /apple[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 8090257d-6b02-4fb4-b2b0-2d3a871eef65
       hee:addToAZ: false
       hee:summary: ''
@@ -138,7 +138,7 @@
     hippo:versionHistory: f5d05ae0-4981-4a4f-94a1-6fd4b5869e67
     /banana[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 06e2cc89-73bc-4fbf-af43-1bbc2c300735
       hee:addToAZ: false
       hee:summary: ''
@@ -177,7 +177,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /banana[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 83150019-125e-42e2-9b5d-23c0e32ea4d9
       hee:addToAZ: false
       hee:summary: ''
@@ -216,7 +216,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /banana[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: b6e7cc22-4517-4e20-a923-4acbb19866a0
       hee:addToAZ: false
       hee:summary: ''
@@ -262,7 +262,7 @@
     hippo:versionHistory: 04d3dcbf-157c-4665-afaf-db99e3391529
     /cherry[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 193ec486-cfe7-4ebd-bf1e-f8fd1661218f
       hee:addToAZ: false
       hee:summary: ''
@@ -301,7 +301,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /cherry[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 9e775166-f6fa-4e07-860e-515240c19f31
       hee:addToAZ: false
       hee:summary: ''
@@ -340,7 +340,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /cherry[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 5cc4cf97-9a83-4249-818d-de9492fc05f7
       hee:addToAZ: false
       hee:summary: ''
@@ -386,7 +386,7 @@
     hippo:versionHistory: 5eeb89ba-6f7c-4b53-8230-0a6530671e11
     /date[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: b4f3c946-9e70-4f00-b44a-6bd5c23b7e08
       hee:addToAZ: false
       hee:summary: ''
@@ -425,7 +425,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /date[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: d626ed0d-525b-47fb-b7a6-d41b48e912f8
       hee:addToAZ: false
       hee:summary: ''
@@ -464,7 +464,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /date[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: a56b8265-3f32-4659-8965-bbbb63670fb6
       hee:addToAZ: false
       hee:summary: ''
@@ -510,7 +510,7 @@
     hippo:versionHistory: 3b3e4789-0062-4ae7-8fed-d879f026f36c
     /elderberry[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: b21c1da0-9bd1-4945-bb33-b6a927a196a5
       hee:addToAZ: true
       hee:summary: ''
@@ -549,7 +549,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /elderberry[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 516229c3-f9c3-4dff-b651-22ef46efdfb6
       hee:addToAZ: true
       hee:summary: ''
@@ -588,7 +588,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /elderberry[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 13db2c65-69cd-4c2d-94fd-679deb6e9a71
       hee:addToAZ: true
       hee:summary: ''
@@ -634,7 +634,7 @@
     hippo:versionHistory: 5991f39b-dc6d-4289-9ee1-7c959e7ecba3
     /fig[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: d38ddf63-65bc-4f6e-9c76-d45ade4f2b2d
       hee:addToAZ: false
       hee:summary: ''
@@ -673,7 +673,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /fig[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: aca96252-4ca1-43fa-bd5a-d67bd3a4c41f
       hee:addToAZ: false
       hee:summary: ''
@@ -712,7 +712,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /fig[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: c60c2587-e1ee-4099-9c0f-f605b8771771
       hee:addToAZ: false
       hee:summary: ''
@@ -758,7 +758,7 @@
     hippo:versionHistory: 6cfb1896-18f3-4e4b-aace-874d7f3e9d5c
     /grapefruit[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: e24e63ab-bf1d-4ee2-b1cf-1d4515806032
       hee:addToAZ: false
       hee:summary: ''
@@ -797,7 +797,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /grapefruit[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 6833ccc0-ac9d-4ee0-ad3b-5297a0c6fbcc
       hee:addToAZ: false
       hee:summary: ''
@@ -836,7 +836,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /grapefruit[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: bf9923df-f2c7-4e0e-b9fb-b126334e0ef9
       hee:addToAZ: false
       hee:summary: ''
@@ -882,7 +882,7 @@
     hippo:versionHistory: 9985b57f-e25c-4e10-bbec-e8b7e1288d9c
     /imbe[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 23c68579-8444-452a-8e14-d7d0e7d4a555
       hee:addToAZ: false
       hee:summary: ''
@@ -921,7 +921,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /imbe[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: a3bdec2a-60a7-4f8c-8063-189a2d7ff831
       hee:addToAZ: false
       hee:summary: ''
@@ -960,7 +960,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /imbe[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 1ac7b62b-436f-438c-9414-1c946099bca4
       hee:addToAZ: false
       hee:summary: ''
@@ -1006,7 +1006,7 @@
     hippo:versionHistory: 480d458b-5c04-4035-a9e0-962cb3ee3cbe
     /aardvark[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 38394626-0870-4d83-855a-4b20a780fe5f
       hee:addToAZ: false
       hee:summary: ''
@@ -1045,7 +1045,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /aardvark[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 541f0540-0f77-4e9d-86a4-b012165b99f5
       hee:addToAZ: false
       hee:summary: ''
@@ -1084,7 +1084,7 @@
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /aardvark[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: b4df4839-36c8-4ad3-8768-9f74f106492c
       hee:addToAZ: false
       hee:summary: ''

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/cookies.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/cookies.yaml
@@ -6,7 +6,7 @@
   hippo:versionHistory: 61f55634-ef55-45b6-b142-9b20bad5a72f
   /cookies[1]:
     jcr:primaryType: hee:guidance
-    jcr:mixinTypes: ['mix:referenceable']
+    jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
     jcr:uuid: a388b00d-4a83-4dd8-9b2e-adb545f5d267
     hee:summary: When we provide online services, we want to make them easy, useful
       and reliable. To make our services work better, we sometimes put small amounts
@@ -88,7 +88,7 @@
         <p>Full details about Google Analytics cookies are published on the <a href="http://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">Google website (opens in new window)</a>. Google also publishes a <a href="http://chrome.google.com/webstore/detail/google-analytics-opt-out/fllaojicojecljbmefodhfapmkghcbnh?hl=en-GB" target="_blank">browser add-on (opens in new window)</a> which lets you stop information about your website visit being sent to Google Analytics.</p>
   /cookies[2]:
     jcr:primaryType: hee:guidance
-    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+    jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
     jcr:uuid: eaf41d9e-39b0-445a-927c-117759e603a9
     hee:summary: When we provide online services, we want to make them easy, useful
       and reliable. To make our services work better, we sometimes put small amounts
@@ -170,7 +170,7 @@
         <p>Full details about Google Analytics cookies are published on the <a href="http://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">Google website (opens in new window)</a>. Google also publishes a <a href="http://chrome.google.com/webstore/detail/google-analytics-opt-out/fllaojicojecljbmefodhfapmkghcbnh?hl=en-GB" target="_blank">browser add-on (opens in new window)</a> which lets you stop information about your website visit being sent to Google Analytics.</p>
   /cookies[3]:
     jcr:primaryType: hee:guidance
-    jcr:mixinTypes: ['mix:referenceable']
+    jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
     jcr:uuid: 3855c93e-531f-4000-9fba-2bb160d2084e
     hee:summary: When we provide online services, we want to make them easy, useful
       and reliable. To make our services work better, we sometimes put small amounts

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/guidance-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/guidance-pages.yaml
@@ -12,10 +12,10 @@
     jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
     jcr:uuid: 9071bfc1-35e4-4cb8-852c-c91f97fb43f0
     hippo:name: Copyright
-    hippo:versionHistory: 8803bcf3-704d-4539-94a0-eee9ac092c1b
+    hippo:versionHistory: 6e29d08d-67a4-409d-9bf4-95bc98add600
     /copyright[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:versionable']
       jcr:uuid: 2385c18e-7cd3-4a31-b0ee-6fde4e50a1ce
       hee:addToAZ: false
       hee:summary: NHS library staff in England may copy and share extracts from most
@@ -24,9 +24,10 @@
       hippo:availability: [preview]
       hippostd:retainable: false
       hippostd:state: unpublished
+      hippostd:tags: [Unit testing]
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2023-05-03T13:42:21.824+05:30
+      hippostdpubwf:lastModificationDate: 2023-05-05T14:11:44.333+01:00
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
@@ -94,8 +95,8 @@
           hippo:values: []
       /hee:pageLastNextReview:
         jcr:primaryType: hee:pageLastNextReview
-        hee:lastReviewed: 2017-02-10T00:00:00+05:30
-        hee:nextReviewed: 2021-02-01T00:00:00+05:30
+        hee:lastReviewed: 2017-02-09T00:00:00Z
+        hee:nextReviewed: 2021-01-31T00:00:00Z
       /hee:contentBlocks[5]:
         jcr:primaryType: hippostd:html
         hippostd:content: <p>HEllo <strong>rich</strong> text</p>
@@ -480,7 +481,7 @@
           hippo:docbase: bef94dde-831c-48e1-b5ae-2a35899c94a1
     /copyright[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: ba968b60-388d-4d63-a2dc-98b62ef48a80
       hee:addToAZ: false
       hee:summary: NHS library staff in England may copy and share extracts from most
@@ -489,9 +490,10 @@
       hippo:availability: []
       hippostd:retainable: false
       hippostd:state: draft
+      hippostd:tags: [Unit testing]
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2023-05-03T13:41:50.719+05:30
+      hippostdpubwf:lastModificationDate: 2023-05-05T14:11:23.583+01:00
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
@@ -559,8 +561,8 @@
           hippo:values: []
       /hee:pageLastNextReview:
         jcr:primaryType: hee:pageLastNextReview
-        hee:lastReviewed: 2017-02-10T00:00:00+05:30
-        hee:nextReviewed: 2021-02-01T00:00:00+05:30
+        hee:lastReviewed: 2017-02-09T00:00:00Z
+        hee:nextReviewed: 2021-01-31T00:00:00Z
       /hee:contentBlocks[5]:
         jcr:primaryType: hippostd:html
         hippostd:content: <p>HEllo <strong>rich</strong> text</p>
@@ -945,7 +947,7 @@
           hippo:docbase: bef94dde-831c-48e1-b5ae-2a35899c94a1
     /copyright[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 35446ae7-be2b-46b0-b915-bb90ae2896b4
       hee:addToAZ: false
       hee:summary: NHS library staff in England may copy and share extracts from most
@@ -954,11 +956,12 @@
       hippo:availability: [live]
       hippostd:retainable: false
       hippostd:state: published
+      hippostd:tags: [Unit testing]
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-02-03T15:52:21.360+07:00
-      hippostdpubwf:lastModificationDate: 2023-05-03T13:42:21.824+05:30
+      hippostdpubwf:lastModificationDate: 2023-05-05T14:11:44.333+01:00
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2023-05-03T13:42:25.094+05:30
+      hippostdpubwf:publicationDate: 2023-05-05T14:11:47.971+01:00
       hippotranslation:id: 203579fe-0110-4d7e-a784-29206ca94a04
       hippotranslation:locale: en
       /hee:contentBlocks[1]:
@@ -1025,8 +1028,8 @@
           hippo:values: []
       /hee:pageLastNextReview:
         jcr:primaryType: hee:pageLastNextReview
-        hee:lastReviewed: 2017-02-10T00:00:00+05:30
-        hee:nextReviewed: 2021-02-01T00:00:00+05:30
+        hee:lastReviewed: 2017-02-09T00:00:00Z
+        hee:nextReviewed: 2021-01-31T00:00:00Z
       /hee:contentBlocks[5]:
         jcr:primaryType: hippostd:html
         hippostd:content: <p>HEllo <strong>rich</strong> text</p>
@@ -1417,7 +1420,7 @@
     hippo:versionHistory: 105093be-ac77-4274-b469-5c6849cf3c86
     /introduction[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:versionable']
       jcr:uuid: f96c9995-bb5e-4abf-90ed-996d1d72e8bb
       hee:addToAZ: false
       hee:summary: NHS library staff in England may copy and share extracts from most
@@ -1625,7 +1628,7 @@
           hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /introduction[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 9ed84b9b-feac-4c36-ac9c-6bebbf96d057
       hee:addToAZ: false
       hee:summary: NHS library staff in England may copy and share extracts from most
@@ -1834,7 +1837,7 @@
           hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
     /introduction[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 15d5ad76-8fb7-443b-8f8b-3c7ce709ffc8
       hee:addToAZ: false
       hee:summary: NHS library staff in England may copy and share extracts from most
@@ -2048,7 +2051,7 @@
     hippo:versionHistory: f04bbd3e-9fde-41fe-b85e-1798c82c646e
     /test-media[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 2182f2fc-4b9f-49bf-9913-3f9ad7368b99
       hee:summary: Test media component. Currently only tested with embed codes from
         Youtube, Vimeo and Anchor FM.
@@ -2137,7 +2140,7 @@
         hippo:values: []
     /test-media[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 9a29f360-baec-4517-9447-d599b40924f5
       hee:summary: Test media component. Currently only tested with embed codes from
         Youtube, Vimeo and Anchor FM.
@@ -2218,7 +2221,7 @@
         hippo:values: []
     /test-media[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: d41e2767-2b55-4e46-ac19-6e3a9a707782
       hee:summary: Test media component. Currently only tested with embed codes from
         Youtube, Vimeo and Anchor FM.
@@ -2306,7 +2309,7 @@
     hippo:versionHistory: 006fcb42-7788-48fd-b48a-8094e769260f
     /newsletter-sign-up[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: ef03a783-a7e3-45c8-a429-5c4a2fa20324
       hee:addToAZ: false
       hee:summary: Fusce sollicitudin sem tristique bibendum sit leo ac placerat rutrum
@@ -2354,7 +2357,7 @@
           hippo:docbase: d65410bd-94b0-48f5-8a57-95c385d75d59
     /newsletter-sign-up[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 029a6a95-8a82-4c59-bfe5-24bbde2c0485
       hee:addToAZ: false
       hee:summary: Fusce sollicitudin sem tristique bibendum sit leo ac placerat rutrum
@@ -2402,7 +2405,7 @@
           hippo:docbase: d65410bd-94b0-48f5-8a57-95c385d75d59
     /newsletter-sign-up[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 4ba242bd-606a-42eb-88f9-cbdaef7d1830
       hee:addToAZ: false
       hee:summary: Fusce sollicitudin sem tristique bibendum sit leo ac placerat rutrum
@@ -2457,7 +2460,7 @@
     hippo:versionHistory: 3a1bd365-f51c-4e04-8f2a-aaee04278437
     /welcome[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: eab4dd15-31c5-4b36-80a9-5968723bbc0b
       hee:addToAZ: false
       hee:summary: This is a simple summary page to which you can add a variety of
@@ -2517,7 +2520,7 @@
           hippo:docbase: a60334fa-81d7-49bc-afc0-a024b6b1a942
     /welcome[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: d7dcf7b4-a971-4aeb-8fa4-5d5cc2bb08c4
       hee:addToAZ: false
       hee:summary: This is a simple summary page to which you can add a variety of
@@ -2577,7 +2580,7 @@
           hippo:docbase: a60334fa-81d7-49bc-afc0-a024b6b1a942
     /welcome[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 430185f8-cd58-4fb8-a0d2-3e70fb03271b
       hee:addToAZ: false
       hee:summary: This is a simple summary page to which you can add a variety of

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/landing-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/landing-pages.yaml
@@ -1,5 +1,5 @@
 /content/documents/lks/landing-pages:
-  .meta:order-before: common
+  .meta:order-before: guidance-pages
   jcr:primaryType: hippostd:folder
   jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   jcr:uuid: d6dc815e-94f5-4d61-a730-f05535c9dddd

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/landing-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/landing-pages.yaml
@@ -1,5 +1,5 @@
 /content/documents/lks/landing-pages:
-  .meta:order-before: guidance-pages
+  .meta:order-before: common
   jcr:primaryType: hippostd:folder
   jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   jcr:uuid: d6dc815e-94f5-4d61-a730-f05535c9dddd

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/visual-regression.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/visual-regression.yaml
@@ -2159,7 +2159,7 @@
     hippo:versionHistory: 4c628d37-57db-47a4-9a04-194802df39bb
     /vr-standard-content-page[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: c0b868ad-71da-40c8-b3ab-74b38d6b8234
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Praesent
@@ -2414,7 +2414,7 @@
           hippo:docbase: a5d0aec9-f46e-4505-9c17-7fc6bf27403f
     /vr-standard-content-page[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: 6d37d71e-b80a-4391-a8c5-ae5beccde70d
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Praesent
@@ -2669,7 +2669,7 @@
           hippo:docbase: a5d0aec9-f46e-4505-9c17-7fc6bf27403f
     /vr-standard-content-page[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 332e8352-44c4-4b0f-bee2-333aa1ec459b
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Praesent
@@ -2931,7 +2931,7 @@
     hippo:versionHistory: 370574a5-6d5e-41ee-a056-7428bfd9740b
     /vr-scp-newsletter-signup-page[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: c95d7b29-e32b-4a1f-be92-9ffde0602738
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Quisque
@@ -2984,7 +2984,7 @@
           hippo:docbase: dfa923ec-941a-497a-ae5d-710c683f32b3
     /vr-scp-newsletter-signup-page[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: ec512dc6-dbf4-4727-a46b-173751b115d0
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Quisque
@@ -3037,7 +3037,7 @@
           hippo:docbase: dfa923ec-941a-497a-ae5d-710c683f32b3
     /vr-scp-newsletter-signup-page[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 86c1c5ab-b2dd-479c-9648-7875d66693ec
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Quisque
@@ -3097,7 +3097,7 @@
     hippo:versionHistory: af13f039-d069-4469-aa80-4cd5842a219b
     /vr-scp-cookies-page[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 79b26279-0ab3-4713-88ef-92de490f2bfe
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Quisque
@@ -3201,7 +3201,7 @@
           <p>These are the cookies we use on the homepage. Other cookies from Hotjar and Google Analytics may be used on other parts of the site. For full descriptions of these cookies, visit <a rel="noopener noreferrer" href="https://help.hotjar.com/hc/en-us/articles/115011789248-Hotjar-Cookie-Information">Hotjar</a> and <a rel="noopener noreferrer" href="https://developers.google.com/analytics/devguides/collection/gajs/cookie-usage#gtagjs_google_analytics_4_-_cookie_usage%5D">Google Analytics</a>.</p>
     /vr-scp-cookies-page[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: a63df15f-8bbc-4194-9599-b1a7ec0ebbbf
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Quisque
@@ -3305,7 +3305,7 @@
           <p>These are the cookies we use on the homepage. Other cookies from Hotjar and Google Analytics may be used on other parts of the site. For full descriptions of these cookies, visit <a rel="noopener noreferrer" href="https://help.hotjar.com/hc/en-us/articles/115011789248-Hotjar-Cookie-Information">Hotjar</a> and <a rel="noopener noreferrer" href="https://developers.google.com/analytics/devguides/collection/gajs/cookie-usage#gtagjs_google_analytics_4_-_cookie_usage%5D">Google Analytics</a>.</p>
     /vr-scp-cookies-page[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: d0ecc670-38f2-4db8-a378-c26c9462fe96
       hee:addToAZ: false
       hee:summary: Quisque velit nisi, pretium ut lacinia in, elementum id enim. Quisque
@@ -3416,7 +3416,7 @@
     hippo:versionHistory: 3ed00a4e-ccd4-4e3c-a786-2464d3999357
     /vr-scp-minin-hub-first-page[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 5e48a14f-efdf-4277-b746-72e84c6f2779
       hee:addToAZ: false
       hee:summary: Sed porttitor lectus nibh. Quisque velit nisi, pretium ut lacinia
@@ -3495,7 +3495,7 @@
           hippo:docbase: 8abb6cfe-b38d-4de5-8948-6bc9d1e6b973
     /vr-scp-minin-hub-first-page[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable', 'mix:versionable']
       jcr:uuid: f4f650a6-3f60-449a-a620-cca6ceadd640
       hee:addToAZ: false
       hee:summary: Sed porttitor lectus nibh. Quisque velit nisi, pretium ut lacinia
@@ -3574,7 +3574,7 @@
           hippo:docbase: 8abb6cfe-b38d-4de5-8948-6bc9d1e6b973
     /vr-scp-minin-hub-first-page[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 2969e01f-d4a5-492d-b201-9dbcba436897
       hee:addToAZ: false
       hee:summary: Sed porttitor lectus nibh. Quisque velit nisi, pretium ut lacinia
@@ -3660,7 +3660,7 @@
     hippo:versionHistory: 186e62b0-3238-49c8-9be8-49597803e137
     /vr-scp-minin-hub-last-page[1]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:versionable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:versionable']
       jcr:uuid: 3f42c8a4-d345-4c1a-acd1-65419efa8b53
       hee:addToAZ: false
       hee:summary: Vestibulum ac diam sit amet quam vehicula elementum sed sit amet
@@ -3740,7 +3740,7 @@
           hippo:docbase: cabc00bf-bd7f-4d0f-89e3-920fa0729bf1
     /vr-scp-minin-hub-last-page[2]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: c91a3be5-26c0-49e0-8a5b-d327da02f0d6
       hee:addToAZ: false
       hee:summary: Vestibulum ac diam sit amet quam vehicula elementum sed sit amet
@@ -3820,7 +3820,7 @@
           hippo:docbase: cabc00bf-bd7f-4d0f-89e3-920fa0729bf1
     /vr-scp-minin-hub-last-page[3]:
       jcr:primaryType: hee:guidance
-      jcr:mixinTypes: ['mix:referenceable']
+      jcr:mixinTypes: ['hippostd:taggable', 'mix:referenceable']
       jcr:uuid: 0d727573-7ccd-4fe7-8ff7-2fa04fad5ac5
       hee:addToAZ: false
       hee:summary: Vestibulum ac diam sit amet quam vehicula elementum sed sit amet

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/Guidance.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/Guidance.java
@@ -53,4 +53,9 @@ public class Guidance extends BaseDocument {
     public ImageSetWithCaption getMicroHero() {
         return getLinkedBean("hee:microHero", ImageSetWithCaption.class);
     }
+
+    @HippoEssentialsGenerated(internalName = "hippostd:tags")
+    public String[] getTags() {
+        return getMultipleProperty("hippostd:tags");
+    }
 }


### PR DESCRIPTION
Please review this.
Applied tagging only for standard content pages and it can be extended for other content types if required by content editors
It appears the language translations (de,en,es,fr,nl,zh) in resourcebundle are default for standard hippostd namespace. We can raise a ticket to remove all except en. /hippo:configuration/hippo:translations/hippo:types