### PR TITLE
[Housekeeping] Fix for `The entity name must immediately follow the '&' in the entity reference`

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/include/page-meta-data.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/include/page-meta-data.ftl
@@ -1,3 +1,4 @@
+<#ftl output_format="HTML">
 <#include "../include/imports.ftl">
 <@hst.defineObjects />
 


### PR DESCRIPTION
Changing the output format to `HTML` for `page-meta-data.ftl` in order to auto escape entities (e.g. `&`, etc) to workaround `The entity name must immediately follow the '&' in the entity reference` error contributed by `<@hst.headContribution...>...</@hst.headContribution>`