### PR TITLE
NWPS-1597-BE-Publication-page-Change-name-display-in-Experience-manager

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations.yaml
@@ -224,7 +224,7 @@ definitions:
               jcr:primaryType: hst:containeritemcomponent
               hst:componentclassname: uk.nhs.hee.web.components.ReportComponent
               hst:iconpath: images/catalog-component-icons/simple-content.svg
-              hst:label: Publication
+              hst:label: Publication page
               hst:template: report-main
             /publication-landing-page:
               jcr:primaryType: hst:containeritemcomponent


### PR DESCRIPTION
Change 'Publication' to 'Publication name' in the components in experience pages