### PR TITLE
Nwps 1598 publication taxonomy type professions healthcare

### DIFF
--- a/cms-dependencies/pom.xml
+++ b/cms-dependencies/pom.xml
@@ -89,5 +89,17 @@
       <artifactId>text-search-replace-frontend</artifactId>
       <version>${bloomreach.text-search-replace.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-addon-frontend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-addon-repository</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/cms/src/main/java/org/onehippo/taxonomy/plugin/ParameterisedTaxonomyBrowser.java
+++ b/cms/src/main/java/org/onehippo/taxonomy/plugin/ParameterisedTaxonomyBrowser.java
@@ -1,0 +1,137 @@
+package org.onehippo.taxonomy.plugin;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.model.IModel;
+import org.hippoecm.frontend.plugins.standards.tree.icon.ITreeNodeIconProvider;
+import org.onehippo.taxonomy.api.Category;
+import org.onehippo.taxonomy.plugin.model.CategoryModel;
+import org.onehippo.taxonomy.plugin.model.Classification;
+import org.onehippo.taxonomy.plugin.model.TaxonomyModel;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * This class extends the TaxonomyBrowser that comes with the Taxonomy plugin for Bloomreach
+ * 
+ * This variant will respect a new property called 'multiple' which defaults to false and which
+ * indicates whether the browser should allow multiple terms to be selected
+ */
+public class ParameterisedTaxonomyBrowser extends TaxonomyBrowser {
+    public static final String ADD = "add";
+    public static final String ADD_ANCESTORS = "addancestors";
+
+    private boolean parameterisedDetailsReadOnly = false;
+
+    protected boolean multiple;
+
+    public ParameterisedTaxonomyBrowser(String id, IModel<Classification> model, TaxonomyModel taxonomyModel, Locale preferredLocale) {
+        super(id, model, taxonomyModel, preferredLocale);
+    }
+
+    public ParameterisedTaxonomyBrowser(String id, IModel<Classification> model, TaxonomyModel taxonomyModel, Locale preferredLocale, boolean detailsReadOnly, ITreeNodeIconProvider iconProvider, boolean multiple) {
+        super(id, model, taxonomyModel, preferredLocale, detailsReadOnly, iconProvider);
+
+        this.multiple = multiple;
+        //* Need to store this for our own access (it's private in the ancestor class)
+        this.parameterisedDetailsReadOnly = detailsReadOnly;
+    }
+
+    /**
+     * By default, the taxonomy picker allows multiple selections, but we can control
+     * that and we need to record the preference rather than assume it is always multi-select
+     */
+    public boolean getMultiple() {
+        return this.multiple;
+    }
+
+    @Override
+    protected Details newDetails(String id, CategoryModel model) {
+        return new ParameterisedDetails(id, model);
+    }
+
+    protected List<String> getKeys() {
+        return getModelObject().getKeys();
+    }
+
+    private boolean isCanonised() {
+        return getModelObject().isCanonised();
+    }
+
+    private void setCanonicalKey(String key) {
+        getModelObject().setCanonical(key);
+    }
+
+    /**
+     * Our own implementation of the {@link TaxonomyBrowser.Details} class which manages teh display of
+     * termas as they are selected in the TreeView on the left of the picker
+     */
+    protected class ParameterisedDetails extends TaxonomyBrowser.Details {
+        /**
+         * In this constructor, we're going to replace the default addition operations so that
+         * they are aware of the multiple selection status
+         * @param id
+         * @param model
+         */
+        public ParameterisedDetails(String id, CategoryModel model) {
+            super(id, model);
+
+            this.addOrReplace(new AjaxLink<Category>(ADD, model) {
+                @Override
+                public void onClick(AjaxRequestTarget target) {
+                    String key = getModelObject().getKey();
+                    List<String> keys = getKeys();
+                    keys.add(key);
+                    if (keys.size() == 1 && isCanonised()) {
+                        setCanonicalKey(key);
+                    }
+                    ParameterisedTaxonomyBrowser.this.modelChanged();
+                    target.add(container);
+                }
+
+                @Override
+                /**
+                 * The change to default behaviour is in here - the multiple check
+                 */
+                public boolean isVisible() {
+                    String key = getModelObject().getKey();
+                    boolean isMulti = ParameterisedTaxonomyBrowser.this.getMultiple();
+                    return !parameterisedDetailsReadOnly && !getKeys().contains(key) &&
+                            ((!isMulti && getKeys().size() == 0) || isMulti);
+                }
+            });
+
+            addOrReplace(new AjaxLink<Category>(ADD_ANCESTORS, model) {
+                @Override
+                public void onClick(AjaxRequestTarget target) {
+                    List<String> keys = getKeys();
+                    for (Category ancestor : getModelObject().getAncestors()) {
+                        if (keys.contains(ancestor.getKey())) {
+                            continue;
+                        }
+                        keys.add(ancestor.getKey());
+                    }
+                    if (keys.size() == 1 && isCanonised()) {
+                        setCanonicalKey(getModelObject().getKey());
+                    }
+                    ParameterisedTaxonomyBrowser.this.modelChanged();
+                    target.add(container);
+                }
+
+                @Override
+                /**
+                 * The change to default behaviour is in here - the multiple check
+                 */
+                public boolean isVisible() {
+                    String key = getModelObject().getKey();
+                    if ((!ParameterisedTaxonomyBrowser.this.getMultiple() && getKeys().size() > 0)
+                            || getModelObject().getParent() == null) {
+                        return false;
+                    }
+                    return !parameterisedDetailsReadOnly && !getKeys().contains(key);
+                }
+            });
+        }
+    }
+}

--- a/cms/src/main/java/uk/nhs/hee/web/taxonomy/ParameterisedTaxonomyDecoder.java
+++ b/cms/src/main/java/uk/nhs/hee/web/taxonomy/ParameterisedTaxonomyDecoder.java
@@ -1,0 +1,38 @@
+package uk.nhs.hee.web.taxonomy;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Use this class to manage decoding of taxonomy names and replacing parameters with values
+ *
+ * Values are generally derived from a pathname (like channel and possibly can be extended
+ * to use something like a region)
+ */
+public class ParameterisedTaxonomyDecoder {
+
+    private final String taxonomyName;
+
+    public ParameterisedTaxonomyDecoder(final String suppliedTaxonomyName) {
+        this.taxonomyName = suppliedTaxonomyName;
+    }
+
+    public boolean isChannelParameterSupplied() {
+        if (taxonomyName == null) {
+            return false;
+        }
+
+        final Pattern channelRegex = Pattern.compile("\\$\\{channel\\}\\-(.*)?");
+        final Matcher documentPathMatcher = channelRegex.matcher(taxonomyName);
+
+        return documentPathMatcher.find();
+    }
+
+    public String replaceChannelParameter(String channel) {
+        if (isChannelParameterSupplied()) {
+            return taxonomyName.replace("${channel}", channel);
+        }
+
+        return taxonomyName;
+    }
+}

--- a/cms/src/main/java/uk/nhs/hee/web/taxonomy/ParameterisedTaxonomyPickerDialog.java
+++ b/cms/src/main/java/uk/nhs/hee/web/taxonomy/ParameterisedTaxonomyPickerDialog.java
@@ -1,0 +1,64 @@
+package uk.nhs.hee.web.taxonomy;
+
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.hippoecm.frontend.plugin.IPluginContext;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.hippoecm.frontend.plugins.cms.browse.tree.FolderTreePlugin;
+import org.hippoecm.frontend.plugins.standards.tree.icon.ITreeNodeIconProvider;
+import org.onehippo.taxonomy.plugin.ITaxonomyService;
+import org.onehippo.taxonomy.plugin.ParameterisedTaxonomyBrowser;
+import org.onehippo.taxonomy.plugin.TaxonomyPickerDialog;
+import org.onehippo.taxonomy.plugin.model.Classification;
+import org.onehippo.taxonomy.plugin.model.TaxonomyModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.hee.web.utils.TaxonomyUtils;
+
+import java.util.Locale;
+
+/**
+ * This is a modified version of the supplied {@link TaxonomyPickerDialog} which is able to
+ * manage parameterised taxonomy names as well as managing selections as single/multiple options
+ */
+public class ParameterisedTaxonomyPickerDialog extends TaxonomyPickerDialog {
+
+    private static final Logger log = LoggerFactory.getLogger(ParameterisedTaxonomyPickerDialog.class);
+
+    public static final String MULTIPLE = "multiple";
+
+    /**
+     * Differs from the original constructor in that it will look for and manage parameterised taxonomy names
+     * @param context
+     * @param config
+     * @param model
+     * @param preferredLocale
+     * @param contextPath
+     */
+    public ParameterisedTaxonomyPickerDialog(IPluginContext context, IPluginConfig config, IModel<Classification> model, Locale preferredLocale, String contextPath) {
+        this(context, config, model, preferredLocale,
+                new TaxonomyModel(context,
+                        config,
+                        null,
+                        TaxonomyUtils.getTaxonomyName(contextPath, config.getString(ITaxonomyService.TAXONOMY_NAME))),
+                false);
+    }
+
+    public ParameterisedTaxonomyPickerDialog(final IPluginContext context, final IPluginConfig config, IModel<Classification> model,
+                                final Locale preferredLocale, final TaxonomyModel taxonomyModel,
+                                final boolean detailsReadOnly) {
+        super(context, config, model, preferredLocale, taxonomyModel, detailsReadOnly);
+        if (!TREE.equals(viewType)) {
+            log.warn("Invalid taxonomy picker type " + viewType + ", falling back to 'tree'");
+        }
+
+        ITreeNodeIconProvider iconProvider = FolderTreePlugin.newTreeNodeIconProvider(context, config);
+        addOrReplace(browser = new ParameterisedTaxonomyBrowser("content", new Model<>(model.getObject()),
+                taxonomyModel, preferredLocale, detailsReadOnly, iconProvider, config.getAsBoolean(MULTIPLE, false)) {
+            @Override
+            protected void onModelChanged() {
+                setOkEnabled(true);
+            }
+        });
+    }
+}

--- a/cms/src/main/java/uk/nhs/hee/web/taxonomy/ParameterisedTaxonomyPickerPlugin.java
+++ b/cms/src/main/java/uk/nhs/hee/web/taxonomy/ParameterisedTaxonomyPickerPlugin.java
@@ -1,0 +1,138 @@
+package uk.nhs.hee.web.taxonomy;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.wicket.Component;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.io.IClusterable;
+import org.hippoecm.frontend.dialog.Dialog;
+import org.hippoecm.frontend.plugin.IPluginContext;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.onehippo.taxonomy.api.Taxonomy;
+import org.onehippo.taxonomy.plugin.ITaxonomyService;
+import org.onehippo.taxonomy.plugin.TaxonomyPickerPlugin;
+import org.onehippo.taxonomy.plugin.model.Classification;
+import org.onehippo.taxonomy.plugin.model.ClassificationModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.hee.web.utils.TaxonomyUtils;
+
+import java.util.Locale;
+
+import javax.jcr.RepositoryException;
+
+public class ParameterisedTaxonomyPickerPlugin extends TaxonomyPickerPlugin {
+    private static final Logger log = LoggerFactory.getLogger(ParameterisedTaxonomyPickerPlugin.class);
+
+    public static final String EDIT = "edit";
+    public static final String MODE = "mode";
+    public static final String BUTTON_TEXT = "button.text";
+    public static final String DIALOG_LINK = "dialog-link";
+    public static final String DIALOG_LINK_TEXT = "dialog-link-text";
+
+    /**
+     * We call the ctor but then adjust the appearance based on whether we are editing
+     * @param context
+     * @param config
+     */
+    public ParameterisedTaxonomyPickerPlugin(IPluginContext context, IPluginConfig config) {
+        super(context, config);
+        replaceButtonTextIfRequired(config);
+    }
+
+    /**
+     * Change "Selecton" button text. Useful when you don't want the "Select the terms" standard text
+     *
+     * @param config which wil include a potential value for the overriding button text
+     */
+    private void replaceButtonTextIfRequired(IPluginConfig config) {
+        if (!EDIT.equals(config.getString(MODE, ""))) {
+            return;
+        }
+
+        final String buttonText = config.getString(BUTTON_TEXT);
+        if (buttonText == null) {
+            return;
+        }
+
+        final Component dialogLink = get(EDIT).get(DIALOG_LINK);
+        if (dialogLink == null) {
+            return;
+        }
+
+        final Component linkText = dialogLink.get(DIALOG_LINK_TEXT);
+        if (linkText == null) {
+            return;
+        }
+
+        linkText.setDefaultModel(Model.of(buttonText));
+    }
+
+    /**
+     * This is our overridden version of the getTaxonomy method which will look for, and replace, parameterised taxonomy names
+     *
+     * Note that we can manage non-parameterised taxonomy names here
+     *
+     * @return the {@link Taxonomy} object which will have been located (or null if none found)
+     */
+    @Override
+    protected Taxonomy getTaxonomy() {
+        final ITaxonomyService service = getService(ITaxonomyService.SERVICE_ID, ITaxonomyService.DEFAULT_SERVICE_TAXONOMY_ID, ITaxonomyService.class);
+        String taxonomyName = getPluginConfig().getString(ITaxonomyService.TAXONOMY_NAME);
+
+        try {
+            taxonomyName = TaxonomyUtils.getTaxonomyName(this.getModel().getObject().getPath(), taxonomyName);
+        } catch (RepositoryException repositoryException) {
+            log.error("Failed to locate/load the taxonomy called '{}'", taxonomyName, repositoryException);
+        }
+
+        if (StringUtils.isBlank(taxonomyName)) {
+            log.info("No configured/chosen taxonomy name. Found '{}'", taxonomyName);
+            return null;
+        } else if (service != null) {
+            return service.getTaxonomy(taxonomyName);
+        } else {
+            log.warn("Taxonomy service not found.");
+            return null;
+        }
+    }
+
+    /**
+     * This is a duplicate of the supplied TaxonomyPickerPlugin#getService(String, String, Class) method, which was declared
+     * private, meaning we are not able to call it from an ancestor class
+     * @param serviceConfigKey
+     * @param defaultServiceId
+     * @param clazz
+     * @param <T>
+     * @return
+     */
+    private <T extends IClusterable> T getService(String serviceConfigKey, String defaultServiceId, Class<T> clazz) {
+        IPluginConfig config = this.getPluginConfig();
+        String serviceId = config.getString(serviceConfigKey, defaultServiceId);
+        if (serviceId == null) {
+            log.debug("ServiceId not found for key {}, config={}", serviceConfigKey, config);
+            return null;
+        } else {
+            IPluginContext context = this.getPluginContext();
+            T service = context.getService(serviceId, clazz);
+            if (service == null) {
+                log.debug("Service {} not found for id {}", clazz.getName(), serviceId);
+            }
+
+            return service;
+        }
+    }
+
+    @Override
+    protected Dialog<Classification> createTaxonomyPickerDialog(ClassificationModel model, Locale preferredLocale) {
+        try {
+            return new ParameterisedTaxonomyPickerDialog(this.getPluginContext(), this.getPluginConfig(),
+                    model,
+                    preferredLocale,
+                    this.getModel().getObject().getPath());
+        } catch (RepositoryException repositoryException) {
+            log.error("Unable to initialise the parent class for the taxonomy picker dialog", repositoryException);
+        }
+
+        return null;
+    }
+}

--- a/cms/src/main/java/uk/nhs/hee/web/taxonomy/ParameterisedTaxonomyPickerPlugin.properties
+++ b/cms/src/main/java/uk/nhs/hee/web/taxonomy/ParameterisedTaxonomyPickerPlugin.properties
@@ -1,0 +1,1 @@
+edit = Select terms

--- a/cms/src/main/java/uk/nhs/hee/web/utils/ChannelUtils.java
+++ b/cms/src/main/java/uk/nhs/hee/web/utils/ChannelUtils.java
@@ -1,11 +1,19 @@
 package uk.nhs.hee.web.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Utility class for channels.
  */
 public class ChannelUtils {
+    private static final Logger log = LoggerFactory.getLogger(ChannelUtils.class);
+
+    private static final Pattern DOCUMENT_PATH_REGEX_PATTERN = Pattern.compile("/content/documents/(.*?)/.*");
 
     /**
      * Private constructor to hide the implicit public one.
@@ -31,4 +39,19 @@ public class ChannelUtils {
         return StringUtils.EMPTY;
     }
 
+    public static String findChannelUsingPattern(final String documentNodePath) {
+        log.debug("Document node path = {}", documentNodePath);
+
+        if (documentNodePath != null) {
+            final Matcher documentPathMatcher = DOCUMENT_PATH_REGEX_PATTERN.matcher(documentNodePath);
+
+            if (documentPathMatcher.find()) {
+                final String channel = documentPathMatcher.group(1);
+                log.debug("Document channel = {}", channel);
+
+                return channel;
+            }
+        }
+        return StringUtils.EMPTY;
+    }
 }

--- a/cms/src/main/java/uk/nhs/hee/web/utils/TaxonomyUtils.java
+++ b/cms/src/main/java/uk/nhs/hee/web/utils/TaxonomyUtils.java
@@ -1,0 +1,31 @@
+package uk.nhs.hee.web.utils;
+
+import uk.nhs.hee.web.taxonomy.ParameterisedTaxonomyDecoder;
+
+/**
+ * Manage a taxonomy name by applying any substitutions to the name that are required
+ *
+ * The default value is to use the originally supplied name
+ */
+public class TaxonomyUtils {
+    public static String getTaxonomyName(String contextPath, String taxonomyName) {
+        String resolvedTaxonomyName = taxonomyName;
+
+        ParameterisedTaxonomyDecoder decoder = new ParameterisedTaxonomyDecoder(taxonomyName);
+
+        if (decoder.isChannelParameterSupplied()) {
+            String channel = ChannelUtils.findChannelUsingPattern(contextPath);
+            resolvedTaxonomyName = getTaxonomyNameUsingChannel(taxonomyName, channel);
+        }
+
+        return resolvedTaxonomyName;
+    }
+
+    private static String getTaxonomyNameUsingChannel(String taxonomyName, String channel) {
+        ParameterisedTaxonomyDecoder decoder = new ParameterisedTaxonomyDecoder(taxonomyName);
+        taxonomyName = decoder.replaceChannelParameter(channel);
+
+        return taxonomyName;
+    }
+
+}

--- a/cms/src/main/java/uk/nhs/hee/web/validation/validator/MandatoryPublicationProfessionsOrTopicsValidator.java
+++ b/cms/src/main/java/uk/nhs/hee/web/validation/validator/MandatoryPublicationProfessionsOrTopicsValidator.java
@@ -8,6 +8,6 @@ import java.util.Arrays;
  */
 public class MandatoryPublicationProfessionsOrTopicsValidator extends AbstractMandatoryCombinationValidator {
     public MandatoryPublicationProfessionsOrTopicsValidator() {
-        super(Arrays.asList(new String[]{"hee:publicationProfessions", "hee:publicationTopics"}));
+        super(Arrays.asList("hippotaxonomy:keys", "hee:publicationTopicsClassifiable"));
     }
 }

--- a/cms/src/main/java/uk/nhs/hee/web/validation/validator/MandatoryPublicationTypeValidator.java
+++ b/cms/src/main/java/uk/nhs/hee/web/validation/validator/MandatoryPublicationTypeValidator.java
@@ -1,0 +1,13 @@
+package uk.nhs.hee.web.validation.validator;
+
+import java.util.Arrays;
+
+/**
+ * Validates if either publication professions ({@code hee:publicationProfessions})
+ * or topics ({@code hee:publicationTopics}) have been provided in the document.
+ */
+public class MandatoryPublicationTypeValidator extends AbstractMandatoryCombinationValidator {
+    public MandatoryPublicationTypeValidator() {
+        super(Arrays.asList("hee:publicationTypeClassifiable"));
+    }
+}

--- a/cms/src/main/java/uk/nhs/hee/web/validation/validator/MandatoryTrainingProgrammeProfessionsOrTopicsValidator.java
+++ b/cms/src/main/java/uk/nhs/hee/web/validation/validator/MandatoryTrainingProgrammeProfessionsOrTopicsValidator.java
@@ -9,6 +9,6 @@ import java.util.Arrays;
 public class MandatoryTrainingProgrammeProfessionsOrTopicsValidator extends AbstractMandatoryCombinationValidator {
 
     public MandatoryTrainingProgrammeProfessionsOrTopicsValidator() {
-        super(Arrays.asList(new String[]{"hee:professions", "hee:topics"}));
+        super(Arrays.asList("hee:professions", "hee:topics"));
     }
 }

--- a/essentials/src/main/resources/taxonomyPlugin.xml
+++ b/essentials/src/main/resources/taxonomyPlugin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<installerDocument>
+    <dateAdded>2023-06-22T16:35:43.032+01:00</dateAdded>
+    <dateInstalled>2023-06-22T16:35:43.032+01:00</dateInstalled>
+    <installationState>installed</installationState>
+</installerDocument>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
@@ -9,6 +9,7 @@ definitions:
     /hippo:configuration/hippo:frontend/cms/cms-services/imageValidationService:
       extensions.allowed: ['*.jpg', '*.jpeg', '*.gif', '*.png']
     /hippo:configuration/hippo:frontend/cms/cms-services/publicationDocumentValidationService:
+      .meta:order-before: global.publication
       jcr:primaryType: frontend:plugin
       extensions.allowed: ['*.pdf', '*.doc', '*.docx', '*.ppt', '*.pptx', '*.xls',
         '*.xlsx', '*.ods', '*.odt']
@@ -26,3 +27,13 @@ definitions:
       plugin.class: com.onehippo.cms7.search.frontend.filters.GenericPropertyFilterPlugin
       wicket.id: ${search.extensions}
       wicket.model: ${model.search}
+    /hippo:configuration/hippo:frontend/cms/cms-services/global.publication:
+      jcr:primaryType: frontend:plugin
+      fieldPath: hee:publicationTypeClassifiable
+      plugin.class: org.onehippo.taxonomy.plugin.MixinClassificationDaoPlugin
+      taxonomy.classification.dao: service.taxonomy.dao.global.publication.classification
+    /hippo:configuration/hippo:frontend/cms/cms-services/global.topics:
+      jcr:primaryType: frontend:plugin
+      fieldPath: hee:publicationTopicsClassifiable
+      plugin.class: org.onehippo.taxonomy.plugin.MixinClassificationDaoPlugin
+      taxonomy.classification.dao: service.taxonomy.dao.global.topics.classification

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/validation.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/validation.yaml
@@ -51,3 +51,9 @@ definitions:
     ? /hippo:configuration/hippo:modules/validation/hippo:moduleconfig/hee:mandatory-training-programme-professions-or-topics-validator
     : jcr:primaryType: hipposys:moduleconfig
       hipposys:className: uk.nhs.hee.web.validation.validator.MandatoryTrainingProgrammeProfessionsOrTopicsValidator
+    /hippo:configuration/hippo:modules/validation/hippo:moduleconfig/hee:mandatory-training-journey-validator:
+      jcr:primaryType: hipposys:moduleconfig
+      hipposys:className: uk.nhs.hee.web.validation.validator.MandatoryTrainingJourneyValidator
+    /hippo:configuration/hippo:modules/validation/hippo:moduleconfig/hee:mandatory-publication-type-validator:
+      jcr:primaryType: hipposys:moduleconfig
+      hipposys:className: uk.nhs.hee.web.validation.validator.MandatoryPublicationTypeValidator

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
@@ -21,7 +21,7 @@ definitions:
       hee:mandatory-publication-professions-or-topics-validator: Please select at
         least one option from either Professions or Topics
       hee:mandatory-training-programme-professions-or-topics-validator: Please select at
-        least one option from either Professions or Topics
+        least one option from either Professions or Healthcare topics
       hee:phone-number-validator#uk-country-code-error: Please remove UK country code
         prefix '+44' from the phone number
       hee:phone-number-validator#invalid-phone-number: Please enter a valid phone
@@ -49,6 +49,8 @@ definitions:
       hee:mandatory-training-journey-validator: When 'Training journey summary' field
         is filled in, you must select at least one link from either 'Prerequisite'
         or 'Optional Route'
+      hee:mandatory-publication-type-validator: Please select a Publication type for
+        this document
     /hippo:configuration/hippo:translations/hippo:cms/advanced-search-filters:
       jcr:primaryType: hipposys:resourcebundles
       /en:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/publicationLandingPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/publicationLandingPage.yaml
@@ -11,12 +11,13 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 21db191c-84af-463d-b36d-f459c019ab51
+          jcr:uuid: dd9d614d-74d8-4c66-a0c6-49d03cc3bf9b
           hipposysedit:node: true
-          hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
+          hipposysedit:supertype: ['hippotranslation:translated', 'hippotaxonomy:classifiable',
+            'hee:basedocument', 'hippostd:relaxed']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
           hipposysedit:validators: ['hee:mandatory-publication-professions-or-topics-validator',
-            'hee:unique-web-publications-validator']
+            'hee:unique-web-publications-validator', 'hee:mandatory-publication-type-validator']
           /title:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -52,31 +53,6 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
             hipposysedit:validators: [required]
-          /publicationType:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: hee:publicationType
-            hipposysedit:primary: false
-            hipposysedit:type: DynamicDropdown
-            hipposysedit:validators: [required]
-          /publicationTopics:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: hee:publicationTopics
-            hipposysedit:primary: false
-            hipposysedit:type: String
-          /publicationProfessions:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: hee:publicationProfessions
-            hipposysedit:primary: false
-            hipposysedit:type: String
           /readTime:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -151,16 +127,23 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: String
             hipposysedit:validators: [email, required]
+          /publicationTypeClassifiable:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:multiple: false
+            hipposysedit:path: hee:publicationTypeClassifiable
+            hipposysedit:type: String
+          /publicationTopicsClassifiable:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:multiple: true
+            hipposysedit:path: hee:publicationTopicsClassifiable
+            hipposysedit:type: String
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
           jcr:primaryType: hee:publicationLandingPage
-          jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 8b71a890-c2ac-4ea5-b848-1d3689f9b64a
+          jcr:mixinTypes: ['mix:referenceable', 'hippotaxonomy:classifiable']
+          jcr:uuid: 776b4fe2-b071-448d-a2e0-b09d5ca7d0f5
           hee:publicationDate: 0001-01-01T12:00:00Z
-          hee:publicationProfessions: []
-          hee:publicationTopics: []
-          hee:publicationType: ''
           hee:subtitle: ''
           hee:summary: ''
           hee:title: ''
@@ -247,17 +230,18 @@ definitions:
             hint: Check the box to hide the authors email address and work address.
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-          /publicationType:
+          /publicationTypeClassifiable:
             jcr:primaryType: frontend:plugin
             caption: Publication type
-            field: publicationType
-            hint: Select the publication type
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            field: publicationTypeClassifiable
+            plugin.class: uk.nhs.hee.web.taxonomy.ParameterisedTaxonomyPickerPlugin
+            taxonomy.classification.dao: service.taxonomy.dao.global.publication.classification
+            taxonomy.id: service.taxonomy
+            taxonomy.name: hee-global-publication-types
             wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              sortComparator: org.onehippo.forge.selection.frontend.plugin.sorting.DefaultListItemComparator
-              source: /content/documents/administration/valuelists/publicationtypes
+            multiple: 'false'
+            hint: Select the publication type
+            button.text: Select publication type
           /summary:
             jcr:primaryType: frontend:plugin
             caption: Summary
@@ -278,38 +262,32 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               nodetypes: ['hee:logoGroup']
-          /publicationProfessions:
+          /classifiable:
             jcr:primaryType: frontend:plugin
-            caption: Professions
-            field: publicationProfessions
-            multiselect.type: palette
-            palette.alloworder: false
-            palette.maxrows: '10'
-            plugin.class: org.onehippo.forge.selection.frontend.plugin.DynamicMultiSelectPlugin
-            selectlist.maxrows: '10'
-            valuelist.provider: service.valuelist.default
+            essentials-taxonomy-name: hee-global-professions
+            mixin: hippotaxonomy:classifiable
+            plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
             wicket.id: ${cluster.id}.left.item
-            hint: Select professions relevant to this publication
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              source: /content/documents/administration/valuelists/publicationprofessions
-              sortComparator: org.onehippo.forge.selection.frontend.plugin.sorting.DefaultListItemComparator
-          /publicationTopics:
+              taxonomy.name: hee-global-professions
+              caption: Professions
+              hint: Choose at least one relevant profession and/or healthcare topic
+                for this content
+              button.text: Select professsions
+          /publicationTopicsClassifiable:
             jcr:primaryType: frontend:plugin
-            caption: Topics
-            field: publicationTopics
-            multiselect.type: palette
-            palette.alloworder: false
-            palette.maxrows: '10'
-            plugin.class: org.onehippo.forge.selection.frontend.plugin.DynamicMultiSelectPlugin
-            selectlist.maxrows: '10'
-            valuelist.provider: service.valuelist.default
+            caption: Healthcare topics
+            field: publicationTopicsClassifiable
+            plugin.class: uk.nhs.hee.web.taxonomy.ParameterisedTaxonomyPickerPlugin
+            taxonomy.classification.dao: service.taxonomy.dao.global.topics.classification
+            taxonomy.id: service.taxonomy
+            taxonomy.name: hee-global-topics
             wicket.id: ${cluster.id}.left.item
-            hint: Select relevant topics
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              source: /content/documents/administration/valuelists/publicationtopics
-              sortComparator: org.onehippo.forge.selection.frontend.plugin.sorting.DefaultListItemComparator
+            hint: Choose at least one relevant profession and/or healthcare topic
+              for this content
+            multiple: 'true'
+            button.text: Select topics
           /publicationDate:
             jcr:primaryType: frontend:plugin
             caption: Publication date

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hippotaxonomy/classifiable.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hippotaxonomy/classifiable.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hippo:namespaces/hippotaxonomy/classifiable/editor:templates/_default_/root:
+      plugin.class: uk.nhs.hee.web.taxonomy.ParameterisedTaxonomyPickerPlugin
+    /hippo:namespaces/hippotaxonomy/classifiable/editor:templates/_default_:
+      frontend:properties: [mode, taxonomy.name, caption, hint, button.text]

--- a/repository-data/application/src/main/resources/hcm-content/taxonomies.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/taxonomies.yaml
@@ -1,0 +1,6026 @@
+/content/taxonomies:
+  jcr:primaryType: hippotaxonomy:container
+  /hee-global-publication-types:
+    jcr:primaryType: hippo:handle
+    jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo']
+    hippo:name: HEE Global Publication Type
+    hippo:versionHistory: 6c6bf01b-9a8d-45d1-9ee1-3ba78be15ddd
+    /hee-global-publication-types[1]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable', 'mix:versionable']
+      jcr:uuid: cdaca5bb-e5cf-4f4e-8e83-9ca3554ec7a8
+      hippo:availability: [preview]
+      hippostd:retainable: false
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-06-22T16:38:03.170+01:00
+      hippostdpubwf:lastModificationDate: 2023-06-22T17:56:56.216+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippotaxonomy:locales: [en]
+      /briefing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: briefing
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Briefing
+    /hee-global-publication-types[2]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:versionable']
+      jcr:uuid: 218bda26-425c-46cc-a336-8591fb436b37
+      hippo:availability: [live]
+      hippostd:holder: admin
+      hippostd:retainable: false
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-06-22T16:38:03.170+01:00
+      hippostdpubwf:lastModificationDate: 2023-06-22T17:56:56.216+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2023-06-22T17:57:00.673+01:00
+      hippotaxonomy:locales: [en]
+      /briefing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: briefing
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Briefing
+      /consultation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: consultation
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Consultation
+      /data-and-statistics:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: data-and-statistics
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Data and statistics
+      /decision:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: decision
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Decision
+      /foi-release:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: foi-release
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: FOI release
+      /guidance:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: guidance
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Guidance
+      /independent-report:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: independent-report
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Independent report
+      /letter:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: letter
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Letter
+      /meeting-papers-and-minutes:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: meeting-papers-and-minutes
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Meeting papers and minutes
+      /contract:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: contract
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Contract
+      /policy-or-strategy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: policy-or-strategy
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Policy or strategy
+      /promotional-material:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: promotional-material
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Promotional material
+      /regulatory:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: regulatory
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Regulatory
+      /report:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: report
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Report
+      /research:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: research
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Research
+      /statement:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: statement
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Statement
+      /data:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: data
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Data
+      /review:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: review
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Review
+      /business-plan:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: business-plan
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Business Plan
+      /framework:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: framework
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Framework
+    /hee-global-publication-types[3]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable']
+      jcr:uuid: c0a4d2d0-8386-4375-8e00-cf7e4a9fb7fd
+      hippo:availability: []
+      hippostd:retainable: false
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-06-22T16:38:03.170+01:00
+      hippostdpubwf:lastModificationDate: 2023-06-22T17:56:56.253+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippotaxonomy:locales: [en]
+      /briefing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: briefing
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Briefing
+  /hee-global-professions:
+    jcr:primaryType: hippo:handle
+    jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo']
+    hippo:name: HEE Global Professions
+    hippo:versionHistory: 9129f6e6-e242-4f09-b343-5dace196c793
+    /hee-global-professions[1]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable']
+      jcr:uuid: a4b59253-6d94-40af-b578-20c4068fe2b1
+      hippo:availability: [live]
+      hippostd:retainable: false
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-06-22T16:38:14.125+01:00
+      hippostdpubwf:lastModificationDate: 2023-06-28T15:44:24.837+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2023-06-29T09:27:32.707+01:00
+      hippotaxonomy:locales: [en]
+      /advanced-critical-care-practitioners:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: advanced-critical-care-practitioners
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Advanced critical care practitioners
+        /anaesthesia-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anaesthesia-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anaesthesia associate
+        /physician-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: physician-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Physician associate
+        /surgical-care-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: surgical-care-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Surgical care practitioner
+      /allied-health-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: allied-health-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Allied health professionals
+        /art-therapist-art-psychotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: art-therapist-art-psychotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Art therapist/art psychotherapist
+        /diagnostic-radiographer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: diagnostic-radiographer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Diagnostic radiographer
+        /dietitian:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dietitian
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dietitian
+        /dramatherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dramatherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dramatherapist
+        /music-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: music-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Music therapist
+        /occupational-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational therapist
+        /operating-department-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: operating-department-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Operating department practitioner
+        /orthoptist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: orthoptist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Orthoptist
+        /osteopath:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: osteopath
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Osteopath
+        /physiotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: physiotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Physiotherapist
+        /podiatrist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: podiatrist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Podiatrist
+        /prosthetist-orthotist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: prosthetist-orthotist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Prosthetist/orthotist
+        /speech-and-language-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: speech-and-language-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Speech and language therapist
+        /therapeutic-radiographer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: therapeutic-radiographer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Therapeutic radiographer
+      /ambulance-service-team:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: ambulance-service-team
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Ambulance service team
+        /ambulance-care-assistant-and-patient-transport-service--pts--driver:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ambulance-care-assistant-and-patient-transport-service--pts--driver
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ambulance care assistant and Patient Transport Service
+                (PTS) driver
+        /call-handler-emergency-medical-dispatcher:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: call-handler-emergency-medical-dispatcher
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Call handler/emergency medical dispatcher
+        /emergency-care-assistant:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-care-assistant
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency care assistant
+        /emergency-medical-technician:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-medical-technician
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency medical technician
+        /experienced-paramedic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: experienced-paramedic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Experienced paramedic
+        /paramedic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paramedic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paramedic
+        /patient-transport-service--pts--call-handler:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: patient-transport-service--pts--call-handler
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Patient Transport Service (PTS) call handler
+      /dental-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: dental-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Dental professionals
+        /dental-hygienist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-hygienist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental hygienist
+        /dental-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental nurse
+        /dental-technician-dental-technologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-technician-dental-technologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental technician/dental technologist
+        /dental-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental therapist
+        /dentist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dentist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dentist
+      /health-informaticians:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-informaticians
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Health informaticians
+        /clinical-informatics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-informatics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical informatics
+        /education-and-training-roles:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: education-and-training-roles
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Education and training roles
+        /health-records-and-patient-administration:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-records-and-patient-administration
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health records and patient administration
+        /information-and-communication-technology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: information-and-communication-technology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Information and communication technology
+        /information-management-staff:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: information-management-staff
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Information management staff
+        /library,-knowledge-and-information-services:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: library,-knowledge-and-information-services
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Library, knowledge and information services
+        /project-and-programme-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-and-programme-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project and programme management
+      /healthcare-scientists:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: healthcare-scientists
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Healthcare scientists
+        /analytical-toxicology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: analytical-toxicology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Analytical toxicology
+        /anatomical-pathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anatomical-pathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anatomical pathology
+        /audiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: audiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Audiology
+        /biomedical-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: biomedical-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Biomedical science
+        /blood-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: blood-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Blood sciences
+        /cancer-genomics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cancer-genomics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cancer genomics
+        /cardiac-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiac-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiac sciences
+        /cellular-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cellular-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cellular sciences
+        /clinical-biochemistry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-biochemistry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical biochemistry
+        /clinical-bioinformatics--genomics-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--genomics-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (genomics)
+        /clinical-bioinformatics--health-informatics-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--health-informatics-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (health informatics)
+        /clinical-bioinformatics--physical-sciences-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--physical-sciences-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (physical sciences)
+        /clinical-immunology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-immunology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical immunology
+        /clinical-measurement:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-measurement
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical measurement
+        /clinical-or-medical-technology-in-medical-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-or-medical-technology-in-medical-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical or medical technology in medical physics
+        /clinical-perfusion-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-perfusion-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical perfusion science
+        /clinical-pharmaceutical-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-pharmaceutical-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical pharmaceutical science
+        /clinical-photography:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-photography
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical photography
+        /critical-care-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: critical-care-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Critical care science
+        /cytopathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cytopathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cytopathology
+        /decontamination-and-sterile-services:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: decontamination-and-sterile-services
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Decontamination and sterile services
+        /gastrointestinal-physiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: gastrointestinal-physiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Gastrointestinal physiology
+        /genomic-counselling:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genomic-counselling
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genomic counselling
+        /genomics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genomics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genomics
+        /haematology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: haematology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Haematology (healthcare scientist)
+        /hearing-aid-dispenser:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: hearing-aid-dispenser
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Hearing aid dispenser
+        /histocompatibility-and-immunogenetics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histocompatibility-and-immunogenetics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histocompatibility and immunogenetics
+        /histopathology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histopathology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histopathology (healthcare scientist)
+        /imaging--ionising-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: imaging--ionising-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Imaging (ionising)
+        /imaging--non-ionising-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: imaging--non-ionising-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Imaging (non-ionising)
+        /infection-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: infection-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Infection sciences
+        /medical-device-risk-management-and-governance:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-device-risk-management-and-governance
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical device risk management and governance
+        /medical-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical engineering
+        /microbiology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: microbiology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Microbiology (healthcare scientist)
+        /neurophysiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurophysiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurophysiology
+        /nuclear-medicine--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nuclear-medicine--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nuclear medicine (healthcare scientist)
+        /ophthalmic-and-vision-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ophthalmic-and-vision-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ophthalmic and vision science
+        /radiation-physics-and-radiation-safety-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: radiation-physics-and-radiation-safety-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Radiation physics and radiation safety physics
+        /radiotherapy-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: radiotherapy-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Radiotherapy physics
+        /reconstructive-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: reconstructive-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Reconstructive science
+        /rehabilitation-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rehabilitation-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rehabilitation engineering
+        /renal-technology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: renal-technology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Renal technology
+        /reproductive-science-and-andrology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: reproductive-science-and-andrology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Reproductive science and andrology
+        /respiratory-physiology-and-sleep-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: respiratory-physiology-and-sleep-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Respiratory physiology and sleep sciences
+        /urodynamic-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: urodynamic-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Urodynamic science
+        /vascular-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: vascular-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Vascular science
+        /virology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: virology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Virology (healthcare scientist)
+      /management-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: management-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Management professionals
+        /administrative-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: administrative-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Administrative management
+        /clinical-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical manager
+        /communications-and-corporate-affairs:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: communications-and-corporate-affairs
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Communications and corporate affairs
+        /decontamination-services-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: decontamination-services-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Decontamination services management
+        /design-and-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: design-and-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Design and engineering
+        /estates-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: estates-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Estates manager
+        /facilities-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: facilities-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Facilities management
+        /finance-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: finance-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Finance manager
+        /hotel-services-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: hotel-services-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Hotel services management
+        /human-resources--hr--manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: human-resources--hr--manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Human resources (HR) manager
+        /integrated-urgent-care-nhs-111-team-leader:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: integrated-urgent-care-nhs-111-team-leader
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Integrated urgent care/NHS 111 team leader
+        /performance-and-quality-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: performance-and-quality-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Performance and quality management
+        /practice-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: practice-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Practice manager
+        /project-management-and-procurement:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-management-and-procurement
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project management and procurement
+        /project-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project manager
+        /purchasing-and-contract-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: purchasing-and-contract-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Purchasing and contract management
+        /strategic-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: strategic-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Strategic management
+      /medical-associate-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: medical-associate-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Medical associate professionals
+      /medical-doctors:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: medical-doctors
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Medical doctors
+        /acute-internal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: acute-internal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Acute internal medicine
+        /allergy:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: allergy
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Allergy
+        /anaesthesia:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anaesthesia
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anaesthesia
+        /audiovestibular-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: audiovestibular-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Audiovestibular medicine
+        /cardiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiology
+        /cardiothoracic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiothoracic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiothoracic surgery
+        /chemical-pathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: chemical-pathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Chemical pathology
+        /child-and-adolescent-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: child-and-adolescent-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Child and adolescent psychiatry
+        /clinical-genetics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-genetics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical genetics
+        /clinical-neurophysiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-neurophysiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical neurophysiology
+        /clinical-oncology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-oncology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical oncology
+        /clinical-pharmacology-and-therapeutics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-pharmacology-and-therapeutics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical pharmacology and therapeutics
+        /clinical-radiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-radiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical radiology
+        /community-sexual-and-reproductive-health:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: community-sexual-and-reproductive-health
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Community sexual and reproductive health
+        /dermatology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dermatology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dermatology
+        /emergency-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency medicine
+        /endocrinology-and-diabetes:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: endocrinology-and-diabetes
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Endocrinology and diabetes
+        /forensic-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: forensic-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Forensic psychiatry
+        /gastroenterology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: gastroenterology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Gastroenterology
+        /general-internal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-internal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General internal medicine
+        /general-practice--gp-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-practice--gp-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General practice (GP)
+        /general-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General psychiatry
+        /general-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General surgery
+        /genitourinary-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genitourinary-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genitourinary medicine
+        /geriatric-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: geriatric-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Geriatric medicine
+        /haematology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: haematology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Haematology (doctor)
+        /histopathology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histopathology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histopathology (doctor)
+        /immunology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: immunology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Immunology
+        /infectious-diseases:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: infectious-diseases
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Infectious diseases
+        /intensive-care-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: intensive-care-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Intensive care medicine
+        /liaison-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: liaison-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Liaison psychiatry
+        /medical-microbiology-and-virology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-microbiology-and-virology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical microbiology and virology (doctor)
+        /medical-oncology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-oncology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical oncology
+        /medical-ophthalmology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-ophthalmology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical ophthalmology
+        /medical-psychotherapy:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-psychotherapy
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical psychotherapy
+        /metabolic-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: metabolic-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Metabolic Medicine
+        /neurology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurology
+        /neurosurgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurosurgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurosurgery
+        /nuclear-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nuclear-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nuclear medicine
+        /obstetrics-and-gynaecology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: obstetrics-and-gynaecology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Obstetrics and gynaecology
+        /occupational-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational medicine
+        /old-age-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: old-age-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Old age psychiatry
+        /ophthalmology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ophthalmology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ophthalmology
+        /oral-and-maxillofacial-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: oral-and-maxillofacial-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Oral and maxillofacial surgery
+        /otorhinolaryngology--ear,-nose-and-throat-surgery,-ent-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: otorhinolaryngology--ear,-nose-and-throat-surgery,-ent-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Otorhinolaryngology (ear, nose and throat surgery,
+                ENT)
+        /paediatric-cardiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatric-cardiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatric cardiology
+        /paediatric-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatric-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatric surgery
+        /paediatrics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatrics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatrics
+        /palliative-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: palliative-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Palliative medicine
+        /pharmaceutical-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmaceutical-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmaceutical medicine
+        /plastic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: plastic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Plastic surgery
+        /psychiatry-of-intellectual-disability--pid-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychiatry-of-intellectual-disability--pid-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychiatry of intellectual disability (PID)
+        /public-health--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health (doctor)
+        /rehabilitation-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rehabilitation-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rehabilitation medicine
+        /renal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: renal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Renal medicine
+        /respiratory-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: respiratory-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Respiratory medicine
+        /rheumatology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rheumatology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rheumatology
+        /sport-and-exercise-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: sport-and-exercise-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Sport and exercise medicine
+        /stroke-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: stroke-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Stroke medicine
+        /trauma-and-orthopaedic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: trauma-and-orthopaedic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Trauma and orthopaedic surgery
+        /tropical-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: tropical-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Tropical medicine
+        /urology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: urology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Urology
+        /vascular-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: vascular-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Vascular surgery
+      /midwives:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: midwives
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Midwives
+        /midwife:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: midwife
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Midwife
+      /nurses:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nurses
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Nurses
+        /adult-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: adult-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Adult nurse
+        /children's-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: children's-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Children's nurse
+        /district-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: district-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: District nurse
+        /general-practice-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-practice-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General practice nurse
+        /learning-disability-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: learning-disability-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Learning disability nurse
+        /mental-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: mental-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Mental health nurse
+        /neonatal-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neonatal-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neonatal nurse
+        /nursing-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nursing-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nursing associate
+        /prison-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: prison-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Prison nurse
+        /theatre-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: theatre-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Theatre nurse
+      /pharmacy-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: pharmacy-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Pharmacy professionals
+        /pharmacist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacist
+        /pharmacy-assistant:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacy-assistant
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacy assistant
+        /pharmacy-technician:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacy-technician
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacy technician
+      /psychological-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: psychological-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Psychological professionals
+        /assistant-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: assistant-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Assistant psychologist
+        /clinical-neuropsychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-neuropsychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical neuropsychologist
+        /clinical-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical psychologist
+        /counselling-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: counselling-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Counselling psychologist
+        /counsellor:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: counsellor
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Counsellor
+        /forensic-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: forensic-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Forensic psychologist
+        /health-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health psychologist
+        /high-intensity-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: high-intensity-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: High intensity therapist
+        /psychological-wellbeing-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychological-wellbeing-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychological wellbeing practitioner
+        /psychotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychotherapist
+      /public-health-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: public-health-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Public health professionals
+        /director-of-public-health:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: director-of-public-health
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Director of public health
+        /environmental-health-professional:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: environmental-health-professional
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Environmental health professional
+        /health-coach:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-coach
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health coach
+        /health-trainer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-trainer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health trainer
+        /health-visitor:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-visitor
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health visitor
+        /occupational-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational health nurse
+        /public-health-academic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-academic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health academic
+        /public-health-consultants-and-specialists:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-consultants-and-specialists
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health consultants and specialists
+        /public-health-knowledge-and-intelligence-professional:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-knowledge-and-intelligence-professional
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health knowledge and intelligence professional
+        /public-health-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health manager
+        /public-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health nurse
+        /public-health-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health practitioner
+        /school-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: school-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: School nurse
+    /hee-global-professions[2]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable', 'mix:versionable']
+      jcr:uuid: af69f0eb-db65-44a7-b43c-bd53bb4de099
+      hippo:availability: [preview]
+      hippostd:retainable: false
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-06-22T16:38:14.125+01:00
+      hippostdpubwf:lastModificationDate: 2023-06-28T15:44:24.837+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippotaxonomy:locales: [en]
+      /advanced-critical-care-practitioners:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: advanced-critical-care-practitioners
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Advanced critical care practitioners
+        /anaesthesia-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anaesthesia-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anaesthesia associate
+          /cat-1:
+            jcr:primaryType: hippotaxonomy:category
+            hippotaxonomy:key: cat-1
+            /hippotaxonomy:categoryinfos:
+              jcr:primaryType: hippotaxonomy:categoryinfos
+              /en:
+                jcr:primaryType: hippotaxonomy:categoryinfo
+                hippotaxonomy:name: Cat 1
+        /physician-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: physician-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Physician associate
+        /surgical-care-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: surgical-care-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Surgical care practitioner
+      /allied-health-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: allied-health-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Allied health professionals
+        /art-therapist-art-psychotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: art-therapist-art-psychotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Art therapist/art psychotherapist
+        /diagnostic-radiographer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: diagnostic-radiographer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Diagnostic radiographer
+        /dietitian:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dietitian
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dietitian
+        /dramatherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dramatherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dramatherapist
+        /music-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: music-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Music therapist
+        /occupational-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational therapist
+        /operating-department-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: operating-department-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Operating department practitioner
+        /orthoptist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: orthoptist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Orthoptist
+        /osteopath:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: osteopath
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Osteopath
+        /physiotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: physiotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Physiotherapist
+        /podiatrist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: podiatrist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Podiatrist
+        /prosthetist-orthotist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: prosthetist-orthotist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Prosthetist/orthotist
+        /speech-and-language-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: speech-and-language-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Speech and language therapist
+        /therapeutic-radiographer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: therapeutic-radiographer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Therapeutic radiographer
+      /ambulance-service-team:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: ambulance-service-team
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Ambulance service team
+        /ambulance-care-assistant-and-patient-transport-service--pts--driver:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ambulance-care-assistant-and-patient-transport-service--pts--driver
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ambulance care assistant and Patient Transport Service
+                (PTS) driver
+        /call-handler-emergency-medical-dispatcher:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: call-handler-emergency-medical-dispatcher
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Call handler/emergency medical dispatcher
+        /emergency-care-assistant:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-care-assistant
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency care assistant
+        /emergency-medical-technician:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-medical-technician
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency medical technician
+        /experienced-paramedic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: experienced-paramedic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Experienced paramedic
+        /paramedic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paramedic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paramedic
+        /patient-transport-service--pts--call-handler:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: patient-transport-service--pts--call-handler
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Patient Transport Service (PTS) call handler
+      /dental-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: dental-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Dental professionals
+        /dental-hygienist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-hygienist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental hygienist
+        /dental-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental nurse
+        /dental-technician-dental-technologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-technician-dental-technologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental technician/dental technologist
+        /dental-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental therapist
+        /dentist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dentist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dentist
+      /health-informaticians:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-informaticians
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Health informaticians
+        /clinical-informatics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-informatics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical informatics
+        /education-and-training-roles:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: education-and-training-roles
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Education and training roles
+        /health-records-and-patient-administration:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-records-and-patient-administration
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health records and patient administration
+        /information-and-communication-technology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: information-and-communication-technology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Information and communication technology
+        /information-management-staff:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: information-management-staff
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Information management staff
+        /library,-knowledge-and-information-services:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: library,-knowledge-and-information-services
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Library, knowledge and information services
+        /project-and-programme-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-and-programme-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project and programme management
+      /healthcare-scientists:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: healthcare-scientists
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Healthcare scientists
+        /analytical-toxicology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: analytical-toxicology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Analytical toxicology
+        /anatomical-pathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anatomical-pathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anatomical pathology
+        /audiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: audiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Audiology
+        /biomedical-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: biomedical-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Biomedical science
+        /blood-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: blood-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Blood sciences
+        /cancer-genomics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cancer-genomics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cancer genomics
+        /cardiac-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiac-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiac sciences
+        /cellular-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cellular-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cellular sciences
+        /clinical-biochemistry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-biochemistry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical biochemistry
+        /clinical-bioinformatics--genomics-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--genomics-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (genomics)
+        /clinical-bioinformatics--health-informatics-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--health-informatics-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (health informatics)
+        /clinical-bioinformatics--physical-sciences-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--physical-sciences-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (physical sciences)
+        /clinical-immunology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-immunology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical immunology
+        /clinical-measurement:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-measurement
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical measurement
+        /clinical-or-medical-technology-in-medical-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-or-medical-technology-in-medical-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical or medical technology in medical physics
+        /clinical-perfusion-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-perfusion-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical perfusion science
+        /clinical-pharmaceutical-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-pharmaceutical-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical pharmaceutical science
+        /clinical-photography:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-photography
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical photography
+        /critical-care-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: critical-care-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Critical care science
+        /cytopathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cytopathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cytopathology
+        /decontamination-and-sterile-services:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: decontamination-and-sterile-services
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Decontamination and sterile services
+        /gastrointestinal-physiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: gastrointestinal-physiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Gastrointestinal physiology
+        /genomic-counselling:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genomic-counselling
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genomic counselling
+        /genomics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genomics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genomics
+        /haematology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: haematology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Haematology (healthcare scientist)
+        /hearing-aid-dispenser:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: hearing-aid-dispenser
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Hearing aid dispenser
+        /histocompatibility-and-immunogenetics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histocompatibility-and-immunogenetics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histocompatibility and immunogenetics
+        /histopathology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histopathology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histopathology (healthcare scientist)
+        /imaging--ionising-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: imaging--ionising-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Imaging (ionising)
+        /imaging--non-ionising-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: imaging--non-ionising-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Imaging (non-ionising)
+        /infection-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: infection-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Infection sciences
+        /medical-device-risk-management-and-governance:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-device-risk-management-and-governance
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical device risk management and governance
+        /medical-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical engineering
+        /microbiology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: microbiology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Microbiology (healthcare scientist)
+        /neurophysiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurophysiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurophysiology
+        /nuclear-medicine--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nuclear-medicine--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nuclear medicine (healthcare scientist)
+        /ophthalmic-and-vision-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ophthalmic-and-vision-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ophthalmic and vision science
+        /radiation-physics-and-radiation-safety-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: radiation-physics-and-radiation-safety-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Radiation physics and radiation safety physics
+        /radiotherapy-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: radiotherapy-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Radiotherapy physics
+        /reconstructive-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: reconstructive-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Reconstructive science
+        /rehabilitation-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rehabilitation-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rehabilitation engineering
+        /renal-technology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: renal-technology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Renal technology
+        /reproductive-science-and-andrology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: reproductive-science-and-andrology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Reproductive science and andrology
+        /respiratory-physiology-and-sleep-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: respiratory-physiology-and-sleep-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Respiratory physiology and sleep sciences
+        /urodynamic-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: urodynamic-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Urodynamic science
+        /vascular-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: vascular-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Vascular science
+        /virology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: virology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Virology (healthcare scientist)
+      /management-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: management-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Management professionals
+        /administrative-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: administrative-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Administrative management
+        /clinical-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical manager
+        /communications-and-corporate-affairs:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: communications-and-corporate-affairs
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Communications and corporate affairs
+        /decontamination-services-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: decontamination-services-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Decontamination services management
+        /design-and-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: design-and-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Design and engineering
+        /estates-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: estates-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Estates manager
+        /facilities-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: facilities-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Facilities management
+        /finance-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: finance-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Finance manager
+        /hotel-services-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: hotel-services-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Hotel services management
+        /human-resources--hr--manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: human-resources--hr--manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Human resources (HR) manager
+        /integrated-urgent-care-nhs-111-team-leader:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: integrated-urgent-care-nhs-111-team-leader
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Integrated urgent care/NHS 111 team leader
+        /performance-and-quality-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: performance-and-quality-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Performance and quality management
+        /practice-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: practice-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Practice manager
+        /project-management-and-procurement:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-management-and-procurement
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project management and procurement
+        /project-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project manager
+        /purchasing-and-contract-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: purchasing-and-contract-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Purchasing and contract management
+        /strategic-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: strategic-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Strategic management
+      /medical-associate-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: medical-associate-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Medical associate professionals
+      /medical-doctors:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: medical-doctors
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Medical doctors
+        /acute-internal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: acute-internal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Acute internal medicine
+        /allergy:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: allergy
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Allergy
+        /anaesthesia:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anaesthesia
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anaesthesia
+        /audiovestibular-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: audiovestibular-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Audiovestibular medicine
+        /cardiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiology
+        /cardiothoracic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiothoracic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiothoracic surgery
+        /chemical-pathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: chemical-pathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Chemical pathology
+        /child-and-adolescent-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: child-and-adolescent-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Child and adolescent psychiatry
+        /clinical-genetics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-genetics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical genetics
+        /clinical-neurophysiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-neurophysiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical neurophysiology
+        /clinical-oncology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-oncology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical oncology
+        /clinical-pharmacology-and-therapeutics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-pharmacology-and-therapeutics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical pharmacology and therapeutics
+        /clinical-radiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-radiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical radiology
+        /community-sexual-and-reproductive-health:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: community-sexual-and-reproductive-health
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Community sexual and reproductive health
+        /dermatology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dermatology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dermatology
+        /emergency-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency medicine
+        /endocrinology-and-diabetes:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: endocrinology-and-diabetes
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Endocrinology and diabetes
+        /forensic-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: forensic-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Forensic psychiatry
+        /gastroenterology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: gastroenterology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Gastroenterology
+        /general-internal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-internal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General internal medicine
+        /general-practice--gp-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-practice--gp-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General practice (GP)
+        /general-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General psychiatry
+        /general-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General surgery
+        /genitourinary-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genitourinary-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genitourinary medicine
+        /geriatric-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: geriatric-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Geriatric medicine
+        /haematology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: haematology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Haematology (doctor)
+        /histopathology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histopathology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histopathology (doctor)
+        /immunology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: immunology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Immunology
+        /infectious-diseases:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: infectious-diseases
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Infectious diseases
+        /intensive-care-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: intensive-care-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Intensive care medicine
+        /liaison-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: liaison-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Liaison psychiatry
+        /medical-microbiology-and-virology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-microbiology-and-virology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical microbiology and virology (doctor)
+        /medical-oncology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-oncology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical oncology
+        /medical-ophthalmology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-ophthalmology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical ophthalmology
+        /medical-psychotherapy:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-psychotherapy
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical psychotherapy
+        /metabolic-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: metabolic-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Metabolic Medicine
+        /neurology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurology
+        /neurosurgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurosurgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurosurgery
+        /nuclear-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nuclear-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nuclear medicine
+        /obstetrics-and-gynaecology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: obstetrics-and-gynaecology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Obstetrics and gynaecology
+        /occupational-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational medicine
+        /old-age-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: old-age-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Old age psychiatry
+        /ophthalmology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ophthalmology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ophthalmology
+        /oral-and-maxillofacial-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: oral-and-maxillofacial-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Oral and maxillofacial surgery
+        /otorhinolaryngology--ear,-nose-and-throat-surgery,-ent-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: otorhinolaryngology--ear,-nose-and-throat-surgery,-ent-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Otorhinolaryngology (ear, nose and throat surgery,
+                ENT)
+        /paediatric-cardiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatric-cardiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatric cardiology
+        /paediatric-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatric-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatric surgery
+        /paediatrics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatrics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatrics
+        /palliative-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: palliative-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Palliative medicine
+        /pharmaceutical-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmaceutical-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmaceutical medicine
+        /plastic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: plastic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Plastic surgery
+        /psychiatry-of-intellectual-disability--pid-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychiatry-of-intellectual-disability--pid-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychiatry of intellectual disability (PID)
+        /public-health--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health (doctor)
+        /rehabilitation-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rehabilitation-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rehabilitation medicine
+        /renal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: renal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Renal medicine
+        /respiratory-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: respiratory-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Respiratory medicine
+        /rheumatology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rheumatology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rheumatology
+        /sport-and-exercise-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: sport-and-exercise-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Sport and exercise medicine
+        /stroke-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: stroke-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Stroke medicine
+        /trauma-and-orthopaedic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: trauma-and-orthopaedic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Trauma and orthopaedic surgery
+        /tropical-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: tropical-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Tropical medicine
+        /urology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: urology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Urology
+        /vascular-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: vascular-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Vascular surgery
+      /midwives:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: midwives
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Midwives
+        /midwife:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: midwife
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Midwife
+      /nurses:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nurses
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Nurses
+        /adult-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: adult-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Adult nurse
+        /children's-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: children's-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Children's nurse
+        /district-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: district-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: District nurse
+        /general-practice-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-practice-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General practice nurse
+        /learning-disability-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: learning-disability-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Learning disability nurse
+        /mental-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: mental-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Mental health nurse
+        /neonatal-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neonatal-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neonatal nurse
+        /nursing-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nursing-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nursing associate
+        /prison-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: prison-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Prison nurse
+        /theatre-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: theatre-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Theatre nurse
+      /pharmacy-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: pharmacy-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Pharmacy professionals
+        /pharmacist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacist
+        /pharmacy-assistant:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacy-assistant
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacy assistant
+        /pharmacy-technician:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacy-technician
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacy technician
+      /psychological-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: psychological-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Psychological professionals
+        /assistant-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: assistant-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Assistant psychologist
+        /clinical-neuropsychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-neuropsychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical neuropsychologist
+        /clinical-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical psychologist
+        /counselling-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: counselling-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Counselling psychologist
+        /counsellor:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: counsellor
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Counsellor
+        /forensic-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: forensic-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Forensic psychologist
+        /health-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health psychologist
+        /high-intensity-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: high-intensity-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: High intensity therapist
+        /psychological-wellbeing-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychological-wellbeing-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychological wellbeing practitioner
+        /psychotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychotherapist
+      /public-health-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: public-health-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Public health professionals
+        /director-of-public-health:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: director-of-public-health
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Director of public health
+        /environmental-health-professional:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: environmental-health-professional
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Environmental health professional
+        /health-coach:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-coach
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health coach
+        /health-trainer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-trainer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health trainer
+        /health-visitor:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-visitor
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health visitor
+        /occupational-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational health nurse
+        /public-health-academic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-academic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health academic
+        /public-health-consultants-and-specialists:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-consultants-and-specialists
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health consultants and specialists
+        /public-health-knowledge-and-intelligence-professional:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-knowledge-and-intelligence-professional
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health knowledge and intelligence professional
+        /public-health-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health manager
+        /public-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health nurse
+        /public-health-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health practitioner
+        /school-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: school-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: School nurse
+    /hee-global-professions[3]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable']
+      jcr:uuid: 00438dea-0949-4bf3-9b4b-2d83d2ab0d2e
+      hippo:availability: []
+      hippostd:retainable: false
+      hippostd:state: draft
+      hippostd:transferable: false
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-06-22T16:38:14.125+01:00
+      hippostdpubwf:lastModificationDate: 2023-06-28T15:44:25.615+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippotaxonomy:locales: [en]
+      /advanced-critical-care-practitioners:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: advanced-critical-care-practitioners
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Advanced critical care practitioners
+        /anaesthesia-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anaesthesia-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anaesthesia associate
+          /cat-1:
+            jcr:primaryType: hippotaxonomy:category
+            hippotaxonomy:key: cat-1
+            /hippotaxonomy:categoryinfos:
+              jcr:primaryType: hippotaxonomy:categoryinfos
+              /en:
+                jcr:primaryType: hippotaxonomy:categoryinfo
+                hippotaxonomy:name: Cat 1
+        /physician-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: physician-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Physician associate
+        /surgical-care-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: surgical-care-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Surgical care practitioner
+      /allied-health-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: allied-health-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Allied health professionals
+        /art-therapist-art-psychotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: art-therapist-art-psychotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Art therapist/art psychotherapist
+        /diagnostic-radiographer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: diagnostic-radiographer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Diagnostic radiographer
+        /dietitian:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dietitian
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dietitian
+        /dramatherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dramatherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dramatherapist
+        /music-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: music-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Music therapist
+        /occupational-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational therapist
+        /operating-department-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: operating-department-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Operating department practitioner
+        /orthoptist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: orthoptist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Orthoptist
+        /osteopath:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: osteopath
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Osteopath
+        /physiotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: physiotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Physiotherapist
+        /podiatrist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: podiatrist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Podiatrist
+        /prosthetist-orthotist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: prosthetist-orthotist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Prosthetist/orthotist
+        /speech-and-language-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: speech-and-language-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Speech and language therapist
+        /therapeutic-radiographer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: therapeutic-radiographer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Therapeutic radiographer
+      /ambulance-service-team:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: ambulance-service-team
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Ambulance service team
+        /ambulance-care-assistant-and-patient-transport-service--pts--driver:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ambulance-care-assistant-and-patient-transport-service--pts--driver
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ambulance care assistant and Patient Transport Service
+                (PTS) driver
+        /call-handler-emergency-medical-dispatcher:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: call-handler-emergency-medical-dispatcher
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Call handler/emergency medical dispatcher
+        /emergency-care-assistant:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-care-assistant
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency care assistant
+        /emergency-medical-technician:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-medical-technician
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency medical technician
+        /experienced-paramedic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: experienced-paramedic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Experienced paramedic
+        /paramedic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paramedic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paramedic
+        /patient-transport-service--pts--call-handler:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: patient-transport-service--pts--call-handler
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Patient Transport Service (PTS) call handler
+      /dental-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: dental-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Dental professionals
+        /dental-hygienist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-hygienist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental hygienist
+        /dental-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental nurse
+        /dental-technician-dental-technologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-technician-dental-technologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental technician/dental technologist
+        /dental-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dental-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dental therapist
+        /dentist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dentist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dentist
+      /health-informaticians:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-informaticians
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Health informaticians
+        /clinical-informatics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-informatics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical informatics
+        /education-and-training-roles:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: education-and-training-roles
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Education and training roles
+        /health-records-and-patient-administration:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-records-and-patient-administration
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health records and patient administration
+        /information-and-communication-technology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: information-and-communication-technology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Information and communication technology
+        /information-management-staff:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: information-management-staff
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Information management staff
+        /library,-knowledge-and-information-services:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: library,-knowledge-and-information-services
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Library, knowledge and information services
+        /project-and-programme-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-and-programme-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project and programme management
+      /healthcare-scientists:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: healthcare-scientists
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Healthcare scientists
+        /analytical-toxicology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: analytical-toxicology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Analytical toxicology
+        /anatomical-pathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anatomical-pathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anatomical pathology
+        /audiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: audiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Audiology
+        /biomedical-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: biomedical-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Biomedical science
+        /blood-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: blood-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Blood sciences
+        /cancer-genomics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cancer-genomics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cancer genomics
+        /cardiac-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiac-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiac sciences
+        /cellular-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cellular-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cellular sciences
+        /clinical-biochemistry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-biochemistry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical biochemistry
+        /clinical-bioinformatics--genomics-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--genomics-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (genomics)
+        /clinical-bioinformatics--health-informatics-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--health-informatics-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (health informatics)
+        /clinical-bioinformatics--physical-sciences-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-bioinformatics--physical-sciences-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical bioinformatics (physical sciences)
+        /clinical-immunology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-immunology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical immunology
+        /clinical-measurement:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-measurement
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical measurement
+        /clinical-or-medical-technology-in-medical-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-or-medical-technology-in-medical-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical or medical technology in medical physics
+        /clinical-perfusion-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-perfusion-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical perfusion science
+        /clinical-pharmaceutical-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-pharmaceutical-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical pharmaceutical science
+        /clinical-photography:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-photography
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical photography
+        /critical-care-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: critical-care-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Critical care science
+        /cytopathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cytopathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cytopathology
+        /decontamination-and-sterile-services:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: decontamination-and-sterile-services
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Decontamination and sterile services
+        /gastrointestinal-physiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: gastrointestinal-physiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Gastrointestinal physiology
+        /genomic-counselling:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genomic-counselling
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genomic counselling
+        /genomics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genomics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genomics
+        /haematology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: haematology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Haematology (healthcare scientist)
+        /hearing-aid-dispenser:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: hearing-aid-dispenser
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Hearing aid dispenser
+        /histocompatibility-and-immunogenetics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histocompatibility-and-immunogenetics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histocompatibility and immunogenetics
+        /histopathology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histopathology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histopathology (healthcare scientist)
+        /imaging--ionising-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: imaging--ionising-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Imaging (ionising)
+        /imaging--non-ionising-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: imaging--non-ionising-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Imaging (non-ionising)
+        /infection-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: infection-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Infection sciences
+        /medical-device-risk-management-and-governance:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-device-risk-management-and-governance
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical device risk management and governance
+        /medical-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical engineering
+        /microbiology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: microbiology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Microbiology (healthcare scientist)
+        /neurophysiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurophysiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurophysiology
+        /nuclear-medicine--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nuclear-medicine--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nuclear medicine (healthcare scientist)
+        /ophthalmic-and-vision-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ophthalmic-and-vision-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ophthalmic and vision science
+        /radiation-physics-and-radiation-safety-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: radiation-physics-and-radiation-safety-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Radiation physics and radiation safety physics
+        /radiotherapy-physics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: radiotherapy-physics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Radiotherapy physics
+        /reconstructive-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: reconstructive-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Reconstructive science
+        /rehabilitation-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rehabilitation-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rehabilitation engineering
+        /renal-technology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: renal-technology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Renal technology
+        /reproductive-science-and-andrology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: reproductive-science-and-andrology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Reproductive science and andrology
+        /respiratory-physiology-and-sleep-sciences:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: respiratory-physiology-and-sleep-sciences
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Respiratory physiology and sleep sciences
+        /urodynamic-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: urodynamic-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Urodynamic science
+        /vascular-science:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: vascular-science
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Vascular science
+        /virology--healthcare-scientist-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: virology--healthcare-scientist-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Virology (healthcare scientist)
+      /management-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: management-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Management professionals
+        /administrative-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: administrative-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Administrative management
+        /clinical-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical manager
+        /communications-and-corporate-affairs:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: communications-and-corporate-affairs
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Communications and corporate affairs
+        /decontamination-services-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: decontamination-services-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Decontamination services management
+        /design-and-engineering:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: design-and-engineering
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Design and engineering
+        /estates-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: estates-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Estates manager
+        /facilities-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: facilities-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Facilities management
+        /finance-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: finance-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Finance manager
+        /hotel-services-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: hotel-services-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Hotel services management
+        /human-resources--hr--manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: human-resources--hr--manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Human resources (HR) manager
+        /integrated-urgent-care-nhs-111-team-leader:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: integrated-urgent-care-nhs-111-team-leader
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Integrated urgent care/NHS 111 team leader
+        /performance-and-quality-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: performance-and-quality-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Performance and quality management
+        /practice-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: practice-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Practice manager
+        /project-management-and-procurement:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-management-and-procurement
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project management and procurement
+        /project-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: project-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Project manager
+        /purchasing-and-contract-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: purchasing-and-contract-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Purchasing and contract management
+        /strategic-management:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: strategic-management
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Strategic management
+      /medical-associate-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: medical-associate-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Medical associate professionals
+      /medical-doctors:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: medical-doctors
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Medical doctors
+        /acute-internal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: acute-internal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Acute internal medicine
+        /allergy:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: allergy
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Allergy
+        /anaesthesia:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: anaesthesia
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Anaesthesia
+        /audiovestibular-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: audiovestibular-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Audiovestibular medicine
+        /cardiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiology
+        /cardiothoracic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: cardiothoracic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Cardiothoracic surgery
+        /chemical-pathology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: chemical-pathology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Chemical pathology
+        /child-and-adolescent-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: child-and-adolescent-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Child and adolescent psychiatry
+        /clinical-genetics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-genetics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical genetics
+        /clinical-neurophysiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-neurophysiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical neurophysiology
+        /clinical-oncology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-oncology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical oncology
+        /clinical-pharmacology-and-therapeutics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-pharmacology-and-therapeutics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical pharmacology and therapeutics
+        /clinical-radiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-radiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical radiology
+        /community-sexual-and-reproductive-health:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: community-sexual-and-reproductive-health
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Community sexual and reproductive health
+        /dermatology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: dermatology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Dermatology
+        /emergency-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: emergency-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Emergency medicine
+        /endocrinology-and-diabetes:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: endocrinology-and-diabetes
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Endocrinology and diabetes
+        /forensic-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: forensic-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Forensic psychiatry
+        /gastroenterology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: gastroenterology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Gastroenterology
+        /general-internal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-internal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General internal medicine
+        /general-practice--gp-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-practice--gp-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General practice (GP)
+        /general-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General psychiatry
+        /general-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General surgery
+        /genitourinary-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: genitourinary-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Genitourinary medicine
+        /geriatric-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: geriatric-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Geriatric medicine
+        /haematology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: haematology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Haematology (doctor)
+        /histopathology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: histopathology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Histopathology (doctor)
+        /immunology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: immunology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Immunology
+        /infectious-diseases:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: infectious-diseases
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Infectious diseases
+        /intensive-care-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: intensive-care-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Intensive care medicine
+        /liaison-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: liaison-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Liaison psychiatry
+        /medical-microbiology-and-virology--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-microbiology-and-virology--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical microbiology and virology (doctor)
+        /medical-oncology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-oncology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical oncology
+        /medical-ophthalmology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-ophthalmology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical ophthalmology
+        /medical-psychotherapy:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: medical-psychotherapy
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Medical psychotherapy
+        /metabolic-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: metabolic-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Metabolic Medicine
+        /neurology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurology
+        /neurosurgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neurosurgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neurosurgery
+        /nuclear-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nuclear-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nuclear medicine
+        /obstetrics-and-gynaecology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: obstetrics-and-gynaecology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Obstetrics and gynaecology
+        /occupational-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational medicine
+        /old-age-psychiatry:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: old-age-psychiatry
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Old age psychiatry
+        /ophthalmology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: ophthalmology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Ophthalmology
+        /oral-and-maxillofacial-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: oral-and-maxillofacial-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Oral and maxillofacial surgery
+        /otorhinolaryngology--ear,-nose-and-throat-surgery,-ent-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: otorhinolaryngology--ear,-nose-and-throat-surgery,-ent-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Otorhinolaryngology (ear, nose and throat surgery,
+                ENT)
+        /paediatric-cardiology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatric-cardiology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatric cardiology
+        /paediatric-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatric-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatric surgery
+        /paediatrics:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: paediatrics
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Paediatrics
+        /palliative-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: palliative-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Palliative medicine
+        /pharmaceutical-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmaceutical-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmaceutical medicine
+        /plastic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: plastic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Plastic surgery
+        /psychiatry-of-intellectual-disability--pid-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychiatry-of-intellectual-disability--pid-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychiatry of intellectual disability (PID)
+        /public-health--doctor-:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health--doctor-
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health (doctor)
+        /rehabilitation-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rehabilitation-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rehabilitation medicine
+        /renal-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: renal-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Renal medicine
+        /respiratory-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: respiratory-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Respiratory medicine
+        /rheumatology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: rheumatology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Rheumatology
+        /sport-and-exercise-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: sport-and-exercise-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Sport and exercise medicine
+        /stroke-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: stroke-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Stroke medicine
+        /trauma-and-orthopaedic-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: trauma-and-orthopaedic-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Trauma and orthopaedic surgery
+        /tropical-medicine:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: tropical-medicine
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Tropical medicine
+        /urology:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: urology
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Urology
+        /vascular-surgery:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: vascular-surgery
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Vascular surgery
+      /midwives:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: midwives
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Midwives
+        /midwife:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: midwife
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Midwife
+      /nurses:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nurses
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Nurses
+        /adult-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: adult-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Adult nurse
+        /children's-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: children's-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Children's nurse
+        /district-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: district-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: District nurse
+        /general-practice-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: general-practice-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: General practice nurse
+        /learning-disability-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: learning-disability-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Learning disability nurse
+        /mental-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: mental-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Mental health nurse
+        /neonatal-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: neonatal-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Neonatal nurse
+        /nursing-associate:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: nursing-associate
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Nursing associate
+        /prison-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: prison-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Prison nurse
+        /theatre-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: theatre-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Theatre nurse
+      /pharmacy-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: pharmacy-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Pharmacy professionals
+        /pharmacist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacist
+        /pharmacy-assistant:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacy-assistant
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacy assistant
+        /pharmacy-technician:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: pharmacy-technician
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Pharmacy technician
+      /psychological-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: psychological-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Psychological professionals
+        /assistant-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: assistant-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Assistant psychologist
+        /clinical-neuropsychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-neuropsychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical neuropsychologist
+        /clinical-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: clinical-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Clinical psychologist
+        /counselling-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: counselling-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Counselling psychologist
+        /counsellor:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: counsellor
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Counsellor
+        /forensic-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: forensic-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Forensic psychologist
+        /health-psychologist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-psychologist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health psychologist
+        /high-intensity-therapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: high-intensity-therapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: High intensity therapist
+        /psychological-wellbeing-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychological-wellbeing-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychological wellbeing practitioner
+        /psychotherapist:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: psychotherapist
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Psychotherapist
+      /public-health-professionals:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: public-health-professionals
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Public health professionals
+        /director-of-public-health:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: director-of-public-health
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Director of public health
+        /environmental-health-professional:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: environmental-health-professional
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Environmental health professional
+        /health-coach:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-coach
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health coach
+        /health-trainer:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-trainer
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health trainer
+        /health-visitor:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: health-visitor
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Health visitor
+        /occupational-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: occupational-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Occupational health nurse
+        /public-health-academic:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-academic
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health academic
+        /public-health-consultants-and-specialists:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-consultants-and-specialists
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health consultants and specialists
+        /public-health-knowledge-and-intelligence-professional:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-knowledge-and-intelligence-professional
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health knowledge and intelligence professional
+        /public-health-manager:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-manager
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health manager
+        /public-health-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health nurse
+        /public-health-practitioner:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: public-health-practitioner
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: Public health practitioner
+        /school-nurse:
+          jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: school-nurse
+          /hippotaxonomy:categoryinfos:
+            jcr:primaryType: hippotaxonomy:categoryinfos
+            /en:
+              jcr:primaryType: hippotaxonomy:categoryinfo
+              hippotaxonomy:name: School nurse
+  /hee-global-topics:
+    jcr:primaryType: hippo:handle
+    jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo']
+    hippo:name: HEE Global Healthcare Topics
+    hippo:versionHistory: b77e8195-d0d4-4eb7-a5a1-3f2ba3327148
+    /hee-global-topics[1]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable', 'mix:versionable']
+      jcr:uuid: 48df165a-fed4-412f-951a-54bcf53387d6
+      hippo:availability: [preview]
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-06-22T16:38:36.503+01:00
+      hippostdpubwf:lastModificationDate: 2023-06-22T16:38:36.503+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippotaxonomy:locales: [en]
+      /addiction:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: addiction
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Addiction
+      /advanced-clinical-practice:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: advanced-clinical-practice
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Advanced clinical practice
+      /antimicrobial-resistance:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: antimicrobial-resistance
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Antimicrobial resistance
+      /armed-forces:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: armed-forces
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Armed Forces
+      /cancer:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: cancer
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Cancer
+      /careers:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: careers
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Careers
+      /children-and-young-people:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: children-and-young-people
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Children and Young People
+      /community-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: community-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Community Care
+      /cosmetic-procedures:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: cosmetic-procedures
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Cosmetic procedures
+      /covid-19:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: covid-19
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Covid-19
+      /critical-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: critical-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Critical Care
+      /dementia:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: dementia
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Dementia
+      /digital-skills:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-skills
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Digital skills
+      /end-of-life-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: end-of-life-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: End of life care
+      /genomics:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: genomics
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Genomics
+      /global-health:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: global-health
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Global Health
+      /health-academia:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-academia
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Health Academia
+      /health-inequalities:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-inequalities
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Health inequalities
+      /infection-management:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: infection-management
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Infection management
+      /knowledge-management:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: knowledge-management
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Knowledge Management
+      /learning-disability-and-autism:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: learning-disability-and-autism
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Learning Disability and Autism
+      /long-term-conditions:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: long-term-conditions
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Long term conditions
+      /maternity:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: maternity
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Maternity
+      /medicines-optimisation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: medicines-optimisation
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Medicines optimisation
+      /mental-health:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: mental-health
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Mental Health
+      /neonatal:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: neonatal
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Neonatal
+      /nhs-screening-services:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nhs-screening-services
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: NHS Screening Services
+      /personalised-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: personalised-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Personalised Care
+      /pre-employment:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: pre-employment
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Pre-employment
+      /prevention-and-public-health:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: prevention-and-public-health
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Prevention and Public Health
+      /primary-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: primary-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Primary Care
+      /quality:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: quality
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Quality
+      /sexual-and-reproductive-health:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: sexual-and-reproductive-health
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Sexual and reproductive health
+      /urgent-and-emergency-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: urgent-and-emergency-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Urgent and Emergency Care
+      /workforce-planning:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: workforce-planning
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Workforce Planning
+      /workforce-transformation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: workforce-transformation
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Workforce Transformation
+    /hee-global-topics[2]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable']
+      jcr:uuid: c9045208-011a-45a6-989a-45042122f4c2
+      hippo:availability: [live]
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-06-22T16:38:36.503+01:00
+      hippostdpubwf:lastModificationDate: 2023-06-22T16:38:36.503+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2023-06-27T09:04:34.046+01:00
+      hippotaxonomy:locales: [en]
+      /addiction:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: addiction
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Addiction
+      /advanced-clinical-practice:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: advanced-clinical-practice
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Advanced clinical practice
+      /antimicrobial-resistance:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: antimicrobial-resistance
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Antimicrobial resistance
+      /armed-forces:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: armed-forces
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Armed Forces
+      /cancer:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: cancer
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Cancer
+      /careers:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: careers
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Careers
+      /children-and-young-people:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: children-and-young-people
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Children and Young People
+      /community-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: community-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Community Care
+      /cosmetic-procedures:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: cosmetic-procedures
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Cosmetic procedures
+      /covid-19:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: covid-19
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Covid-19
+      /critical-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: critical-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Critical Care
+      /dementia:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: dementia
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Dementia
+      /digital-skills:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-skills
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Digital skills
+      /end-of-life-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: end-of-life-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: End of life care
+      /genomics:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: genomics
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Genomics
+      /global-health:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: global-health
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Global Health
+      /health-academia:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-academia
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Health Academia
+      /health-inequalities:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-inequalities
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Health inequalities
+      /infection-management:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: infection-management
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Infection management
+      /knowledge-management:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: knowledge-management
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Knowledge Management
+      /learning-disability-and-autism:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: learning-disability-and-autism
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Learning Disability and Autism
+      /long-term-conditions:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: long-term-conditions
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Long term conditions
+      /maternity:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: maternity
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Maternity
+      /medicines-optimisation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: medicines-optimisation
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Medicines optimisation
+      /mental-health:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: mental-health
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Mental Health
+      /neonatal:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: neonatal
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Neonatal
+      /nhs-screening-services:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nhs-screening-services
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: NHS Screening Services
+      /personalised-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: personalised-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Personalised Care
+      /pre-employment:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: pre-employment
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Pre-employment
+      /prevention-and-public-health:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: prevention-and-public-health
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Prevention and Public Health
+      /primary-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: primary-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Primary Care
+      /quality:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: quality
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Quality
+      /sexual-and-reproductive-health:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: sexual-and-reproductive-health
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Sexual and reproductive health
+      /urgent-and-emergency-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: urgent-and-emergency-care
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Urgent and Emergency Care
+      /workforce-planning:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: workforce-planning
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Workforce Planning
+      /workforce-transformation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: workforce-transformation
+        /hippotaxonomy:categoryinfos:
+          jcr:primaryType: hippotaxonomy:categoryinfos
+          /en:
+            jcr:primaryType: hippotaxonomy:categoryinfo
+            hippotaxonomy:name: Workforce Transformation

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/common.yaml
@@ -2466,13 +2466,13 @@
                 hippo:docbase: 63a42782-36aa-4a06-9e9c-6fb81871ca41
         /vr-publication-landing-page:
           jcr:primaryType: hippo:handle
-          jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
+          jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable','hippotaxonomy:classifiable']
           jcr:uuid: 4d5a2903-72bc-4c6c-a056-13971b0be6df
           hippo:name: '[VR] Publication landing page'
           hippo:versionHistory: 3b7875a4-bd2c-4bb8-8e69-fe04811e8006
           /vr-publication-landing-page[1]:
             jcr:primaryType: hee:ContentCard
-            jcr:mixinTypes: ['mix:versionable']
+            jcr:mixinTypes: ['mix:versionable','hippotaxonomy:classifiable']
             jcr:uuid: 8779bf6a-14af-40d6-9418-9834b509568c
             hee:description: 'Visual regression: Publication landing page'
             hippo:availability: [preview]
@@ -2500,7 +2500,7 @@
                 hippo:docbase: f0d11554-8116-4ec9-b614-fbc9f2b3b8b6
           /vr-publication-landing-page[2]:
             jcr:primaryType: hee:ContentCard
-            jcr:mixinTypes: ['mix:referenceable']
+            jcr:mixinTypes: ['mix:referenceable','hippotaxonomy:classifiable']
             jcr:uuid: 0a0f6561-a2d0-4c8c-b7d9-e48f603837e9
             hee:description: 'Visual regression: Publication landing page'
             hippo:availability: []
@@ -2528,7 +2528,7 @@
                 hippo:docbase: f0d11554-8116-4ec9-b614-fbc9f2b3b8b6
           /vr-publication-landing-page[3]:
             jcr:primaryType: hee:ContentCard
-            jcr:mixinTypes: ['mix:referenceable']
+            jcr:mixinTypes: ['mix:referenceable','hippotaxonomy:classifiable']
             jcr:uuid: 6bcab6e1-d5b2-4bec-b95e-c66cb5e6a63e
             hee:description: 'Visual regression: Publication landing page'
             hippo:availability: [live]

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/publications.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/publications.yaml
@@ -25,18 +25,16 @@
         jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
         jcr:uuid: 973c1c98-ab7a-420f-bb7c-109a9ddd9926
         hippo:name: Reasonable adjustments policy - Publication landing
-        hippo:versionHistory: 39d9f3ac-dd3d-444c-a2bf-90a5a16524a8
+        hippo:versionHistory: 6859fbaf-acf9-4ac8-9c9f-a260ac234d57
         /reasonable-adjustments-policy---publication-landing[1]:
           jcr:primaryType: hee:publicationLandingPage
-          jcr:mixinTypes: ['mix:referenceable']
+          jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
           jcr:uuid: 48e8515a-6a01-4e04-bb8e-6f06775f58f2
           hee:hideAuthorContactDetails: true
           hee:otherFormatsEmail: charles@king.com
           hee:publicationDate: 2022-11-28T00:00:00Z
-          hee:publicationProfessions: [public_health_professionals]
-          hee:publicationTopics: [knowledge_management, quality, workforce_planning,
-            workforce_transformation]
-          hee:publicationType: policy_strategy
+          hee:publicationTopicsClassifiable: [critical-care]
+          hee:publicationTypeClassifiable: [letter]
           hee:readTime: '5'
           hee:subtitle: NSHCS Policies
           hee:summary: The Reasonable Adjustments Policy enables you to request reasonable
@@ -46,14 +44,14 @@
           hee:title: Reasonable adjustments policy
           hee:updatedDate: 2022-12-31T00:00:00Z
           hippo:availability: []
-          hippostd:holder: admin
           hippostd:retainable: false
           hippostd:state: draft
           hippostd:transferable: false
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T20:59:50.608Z
-          hippostdpubwf:lastModificationDate: 2023-06-21T15:22:06.588+01:00
+          hippostdpubwf:lastModificationDate: 2023-07-18T13:22:18.954+01:00
           hippostdpubwf:lastModifiedBy: admin
+          hippotaxonomy:keys: [management-professionals, administrative-management]
           hippotranslation:id: 29f7255a-eaaf-4cfe-8c4c-095423031152
           hippotranslation:locale: en
           /hee:logoGroup:
@@ -87,15 +85,13 @@
               hippo:docbase: 7e13bd69-b4d5-461a-8564-e0436ba5813e
         /reasonable-adjustments-policy---publication-landing[2]:
           jcr:primaryType: hee:publicationLandingPage
-          jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+          jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
           jcr:uuid: 0abfe671-b25a-49d9-adab-4288e720fd55
           hee:hideAuthorContactDetails: true
           hee:otherFormatsEmail: charles@king.com
           hee:publicationDate: 2022-11-28T00:00:00Z
-          hee:publicationProfessions: [public_health_professionals]
-          hee:publicationTopics: [knowledge_management, quality, workforce_planning,
-            workforce_transformation]
-          hee:publicationType: policy_strategy
+          hee:publicationTopicsClassifiable: [critical-care]
+          hee:publicationTypeClassifiable: [letter]
           hee:readTime: '5'
           hee:subtitle: NSHCS Policies
           hee:summary: The Reasonable Adjustments Policy enables you to request reasonable
@@ -110,8 +106,9 @@
           hippostd:transferable: false
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T20:59:50.608Z
-          hippostdpubwf:lastModificationDate: 2023-06-20T18:26:57.168+01:00
+          hippostdpubwf:lastModificationDate: 2023-07-17T13:36:51.233+01:00
           hippostdpubwf:lastModifiedBy: admin
+          hippotaxonomy:keys: [management-professionals, administrative-management]
           hippotranslation:id: 29f7255a-eaaf-4cfe-8c4c-095423031152
           hippotranslation:locale: en
           /hee:logoGroup:
@@ -145,15 +142,13 @@
               hippo:docbase: 7e13bd69-b4d5-461a-8564-e0436ba5813e
         /reasonable-adjustments-policy---publication-landing[3]:
           jcr:primaryType: hee:publicationLandingPage
-          jcr:mixinTypes: ['mix:referenceable']
+          jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
           jcr:uuid: 11dacd51-85cc-42b7-b3e6-dd7b9880a83a
           hee:hideAuthorContactDetails: true
           hee:otherFormatsEmail: charles@king.com
           hee:publicationDate: 2022-11-28T00:00:00Z
-          hee:publicationProfessions: [public_health_professionals]
-          hee:publicationTopics: [knowledge_management, quality, workforce_planning,
-            workforce_transformation]
-          hee:publicationType: policy_strategy
+          hee:publicationTopicsClassifiable: [critical-care]
+          hee:publicationTypeClassifiable: [letter]
           hee:readTime: '5'
           hee:subtitle: NSHCS Policies
           hee:summary: The Reasonable Adjustments Policy enables you to request reasonable
@@ -168,9 +163,10 @@
           hippostd:transferable: false
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T20:59:50.608Z
-          hippostdpubwf:lastModificationDate: 2023-06-20T18:26:57.168+01:00
+          hippostdpubwf:lastModificationDate: 2023-07-17T13:36:51.233+01:00
           hippostdpubwf:lastModifiedBy: admin
-          hippostdpubwf:publicationDate: 2023-06-20T18:27:00.255+01:00
+          hippostdpubwf:publicationDate: 2023-07-18T13:20:59.275+01:00
+          hippotaxonomy:keys: [management-professionals, administrative-management]
           hippotranslation:id: 29f7255a-eaaf-4cfe-8c4c-095423031152
           hippotranslation:locale: en
           /hee:logoGroup:
@@ -1078,16 +1074,16 @@
         jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
         jcr:uuid: 126cc010-dbdd-4149-bc68-68312a63fc2f
         hippo:name: Higher Specialist Scientist Training - Publication landing
-        hippo:versionHistory: a515f498-3074-48e8-bc69-9f773ae8d431
+        hippo:versionHistory: 73590b68-9bbb-45d6-a10f-b5b308f643fa
         /higher-specialist-scientist-training---publication-landing[1]:
           jcr:primaryType: hee:publicationLandingPage
-          jcr:mixinTypes: ['mix:referenceable']
+          jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
           jcr:uuid: 73871551-caa4-4b43-8501-6ca011e09c7a
+          hee:hideAuthorContactDetails: false
+          hee:otherFormatsEmail: yay@hee.com
           hee:publicationDate: 2022-11-28T00:00:00Z
-          hee:publicationProfessions: [healthcare_scientists, public_health_professionals]
-          hee:publicationTopics: [workforce_planning, workforce_transformation, learning_disability_and_autism,
-            pre_employment, careers]
-          hee:publicationType: consultation
+          hee:publicationTopicsClassifiable: []
+          hee:publicationTypeClassifiable: [consultation]
           hee:readTime: '10'
           hee:subtitle: HSST Recruitment
           hee:summary: This is the job advertisement for recruitment to the HSST programme
@@ -1101,8 +1097,9 @@
           hippostd:transferable: false
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T21:23:22.091Z
-          hippostdpubwf:lastModificationDate: 2022-11-28T21:23:22.091Z
+          hippostdpubwf:lastModificationDate: 2023-07-18T13:22:26.224+01:00
           hippostdpubwf:lastModifiedBy: admin
+          hippotaxonomy:keys: [dental-professionals]
           hippotranslation:id: 377227c3-25e1-4ded-83cd-7b04d6f9f404
           hippotranslation:locale: en
           /hee:logoGroup:
@@ -1133,13 +1130,13 @@
             jcr:mimeType: application/vnd.hippo.blank
         /higher-specialist-scientist-training---publication-landing[2]:
           jcr:primaryType: hee:publicationLandingPage
-          jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+          jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
           jcr:uuid: e1650153-5391-4632-9d27-7965b47ce4fa
+          hee:hideAuthorContactDetails: false
+          hee:otherFormatsEmail: yay@hee.com
           hee:publicationDate: 2022-11-28T00:00:00Z
-          hee:publicationProfessions: [healthcare_scientists, public_health_professionals]
-          hee:publicationTopics: [workforce_planning, workforce_transformation, learning_disability_and_autism,
-            pre_employment, careers]
-          hee:publicationType: consultation
+          hee:publicationTopicsClassifiable: []
+          hee:publicationTypeClassifiable: [consultation]
           hee:readTime: '10'
           hee:subtitle: HSST Recruitment
           hee:summary: This is the job advertisement for recruitment to the HSST programme
@@ -1153,8 +1150,9 @@
           hippostd:transferable: false
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T21:23:22.091Z
-          hippostdpubwf:lastModificationDate: 2022-11-28T21:36:05.299Z
+          hippostdpubwf:lastModificationDate: 2023-06-30T12:30:20.733+01:00
           hippostdpubwf:lastModifiedBy: admin
+          hippotaxonomy:keys: [dental-professionals]
           hippotranslation:id: 377227c3-25e1-4ded-83cd-7b04d6f9f404
           hippotranslation:locale: en
           /hee:logoGroup:
@@ -1185,13 +1183,13 @@
             jcr:mimeType: application/vnd.hippo.blank
         /higher-specialist-scientist-training---publication-landing[3]:
           jcr:primaryType: hee:publicationLandingPage
-          jcr:mixinTypes: ['mix:referenceable']
+          jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
           jcr:uuid: 7204e177-bb3e-4ced-be5c-89ae36034711
+          hee:hideAuthorContactDetails: false
+          hee:otherFormatsEmail: yay@hee.com
           hee:publicationDate: 2022-11-28T00:00:00Z
-          hee:publicationProfessions: [healthcare_scientists, public_health_professionals]
-          hee:publicationTopics: [workforce_planning, workforce_transformation, learning_disability_and_autism,
-            pre_employment, careers]
-          hee:publicationType: consultation
+          hee:publicationTopicsClassifiable: []
+          hee:publicationTypeClassifiable: [consultation]
           hee:readTime: '10'
           hee:subtitle: HSST Recruitment
           hee:summary: This is the job advertisement for recruitment to the HSST programme
@@ -1205,9 +1203,10 @@
           hippostd:transferable: false
           hippostdpubwf:createdBy: admin
           hippostdpubwf:creationDate: 2022-11-28T21:23:22.091Z
-          hippostdpubwf:lastModificationDate: 2022-11-28T21:36:05.299Z
+          hippostdpubwf:lastModificationDate: 2023-06-30T12:30:20.733+01:00
           hippostdpubwf:lastModifiedBy: admin
-          hippostdpubwf:publicationDate: 2022-11-28T21:53:36.327Z
+          hippostdpubwf:publicationDate: 2023-07-18T13:22:35.757+01:00
+          hippotaxonomy:keys: [dental-professionals]
           hippotranslation:id: 377227c3-25e1-4ded-83cd-7b04d6f9f404
           hippotranslation:locale: en
           /hee:logoGroup:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/training-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/training-pages.yaml
@@ -1,5 +1,4 @@
 /content/documents/lks/training-pages:
-  .meta:order-before: training-programmes-pages
   jcr:primaryType: hippostd:folder
   jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   jcr:uuid: 5b8c676c-0607-474c-aa52-2157c02a8df9

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/visual-regression.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/visual-regression.yaml
@@ -3883,17 +3883,19 @@
       jcr:mixinTypes: ['hippo:named', 'hippo:versionInfo', 'mix:referenceable']
       jcr:uuid: f0d11554-8116-4ec9-b614-fbc9f2b3b8b6
       hippo:name: '[VR] Publication landing page'
-      hippo:versionHistory: bdf438a0-870d-4e37-8753-a7323aa97683
+      hippo:versionHistory: fe6f7c26-c8db-4db0-8ed6-c9d1895ca616
       /vr-publication-landing-page[1]:
         jcr:primaryType: hee:publicationLandingPage
-        jcr:mixinTypes: ['mix:referenceable']
+        jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
         jcr:uuid: c1b05457-d9d0-446c-923c-de3f38976415
         hee:hideAuthorContactDetails: false
+        hee:otherFormatsEmail: vr-landing@hee.org.uk
         hee:publicationDate: 2023-02-08T00:00:00Z
         hee:publicationProfessions: [pharmacy_professionals, public_health_professionals,
           medical_doctors]
         hee:publicationTopics: [global_health, health_academia, learning_disability_and_autism]
         hee:publicationType: data
+        hee:publicationTypeClassifiable: [decision]
         hee:readTime: '5'
         hee:subtitle: Curabitur non nulla sit amet nisl tempus
         hee:summary: Vivamus suscipit tortor eget felis porttitor volutpat. Cras ultricies
@@ -3904,10 +3906,12 @@
         hippo:availability: []
         hippostd:retainable: false
         hippostd:state: draft
+        hippostd:transferable: false
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2023-02-08T16:29:02.361Z
-        hippostdpubwf:lastModificationDate: 2023-05-30T15:47:42.037+01:00
+        hippostdpubwf:lastModificationDate: 2023-07-19T12:11:18.250+01:00
         hippostdpubwf:lastModifiedBy: admin
+        hippotaxonomy:keys: [dietitian]
         hippotranslation:id: 93d735b2-65ea-47d7-8a4e-c186e21a3703
         hippotranslation:locale: en
         /hee:logoGroup:
@@ -3938,14 +3942,16 @@
             hippo:docbase: 7e13bd69-b4d5-461a-8564-e0436ba5813e
       /vr-publication-landing-page[2]:
         jcr:primaryType: hee:publicationLandingPage
-        jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
+        jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
         jcr:uuid: 4a517cc6-31b3-4622-9ade-2c5468f16519
         hee:hideAuthorContactDetails: false
+        hee:otherFormatsEmail: vr-landing@hee.org.uk
         hee:publicationDate: 2023-02-08T00:00:00Z
         hee:publicationProfessions: [pharmacy_professionals, public_health_professionals,
           medical_doctors]
         hee:publicationTopics: [global_health, health_academia, learning_disability_and_autism]
         hee:publicationType: data
+        hee:publicationTypeClassifiable: [decision]
         hee:readTime: '5'
         hee:subtitle: Curabitur non nulla sit amet nisl tempus
         hee:summary: Vivamus suscipit tortor eget felis porttitor volutpat. Cras ultricies
@@ -3958,8 +3964,9 @@
         hippostd:state: unpublished
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2023-02-08T16:29:02.361Z
-        hippostdpubwf:lastModificationDate: 2023-05-30T15:48:17.665+01:00
+        hippostdpubwf:lastModificationDate: 2023-07-18T17:39:32.634+01:00
         hippostdpubwf:lastModifiedBy: admin
+        hippotaxonomy:keys: [dietitian]
         hippotranslation:id: 93d735b2-65ea-47d7-8a4e-c186e21a3703
         hippotranslation:locale: en
         /hee:logoGroup:
@@ -3990,14 +3997,16 @@
             hippo:docbase: 7e13bd69-b4d5-461a-8564-e0436ba5813e
       /vr-publication-landing-page[3]:
         jcr:primaryType: hee:publicationLandingPage
-        jcr:mixinTypes: ['mix:referenceable']
+        jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
         jcr:uuid: 41f9016f-fcdf-4336-86ff-39220945154c
         hee:hideAuthorContactDetails: false
+        hee:otherFormatsEmail: vr-landing@hee.org.uk
         hee:publicationDate: 2023-02-08T00:00:00Z
         hee:publicationProfessions: [pharmacy_professionals, public_health_professionals,
           medical_doctors]
         hee:publicationTopics: [global_health, health_academia, learning_disability_and_autism]
         hee:publicationType: data
+        hee:publicationTypeClassifiable: [decision]
         hee:readTime: '5'
         hee:subtitle: Curabitur non nulla sit amet nisl tempus
         hee:summary: Vivamus suscipit tortor eget felis porttitor volutpat. Cras ultricies
@@ -4010,9 +4019,10 @@
         hippostd:state: published
         hippostdpubwf:createdBy: admin
         hippostdpubwf:creationDate: 2023-02-08T16:29:02.361Z
-        hippostdpubwf:lastModificationDate: 2023-05-30T15:48:17.665+01:00
+        hippostdpubwf:lastModificationDate: 2023-07-18T17:39:32.634+01:00
         hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2023-06-26T15:34:40.217+05:30
+        hippostdpubwf:publicationDate: 2023-07-18T17:41:35.222+01:00
+        hippotaxonomy:keys: [dietitian]
         hippotranslation:id: 93d735b2-65ea-47d7-8a4e-c186e21a3703
         hippotranslation:locale: en
         /hee:logoGroup:
@@ -5171,7 +5181,7 @@
       hippo:versionHistory: 3de9be38-a44e-4183-b4d0-bfdf7b60fa24
       /vr-search-listing-page[1]:
         jcr:primaryType: hee:listingPage
-        jcr:mixinTypes: ['mix:referenceable']
+        jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
         jcr:uuid: a4633c32-b498-4c75-a56c-4faea7ba9e77
         hee:addToAZ: false
         hee:documentTypes: ['hee:blogPost', 'hee:bulletin', 'hee:caseStudy', 'hee:event',

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
@@ -4,6 +4,7 @@
 <#import "../macros/components.ftl" as hee>
 <#include "../macros/author-cards.ftl">
 <#include "../macros/internal-link.ftl">
+<#include "../macros/publication-partial-info.ftl">
 <#include '../utils/author-util.ftl'>
 <#include '../utils/date-util.ftl'>
 <#include "../utils/document-formats.ftl">
@@ -123,12 +124,14 @@
                     </#if>
                     <#--  Documents section: END  -->
 
+                    <#if document.otherFormatsEmail??>
                     <h2>Other formats</h2>
                     <div class="hee-publication-doc">
                         <p>If you need documents in a different format like accessible PDF,&nbsp;
                         large print, easy read, audio recording or braille please email&nbsp;
                         <a href="mailto:${document.otherFormatsEmail}">${document.otherFormatsEmail}</a></p>
                     </div>
+                    </#if>
 
                     <#--  Author cards  -->
                     <@authorCards authors=document.authors hideAuthorContactDetails=document.hideAuthorContactDetails!false/>
@@ -152,47 +155,10 @@
                         <span>Updated:</span> ${getDefaultFormattedDate(document.updatedDate)}
                     </div>
 
-                    <#--  Publication type  -->
-                    <div class="hee-card--details__item">
-                        <span>Publication Type:</span>
-                        <#if publicationListingPageURL?has_content>
-                            <a href=${publicationListingPageURL}?publicationType=${document.publicationType}>${publicationTypeMap[document.publicationType]}</a>
-                        <#else>
-                            ${publicationTypeMap[document.publicationType]}
-                        </#if>
-                    </div>
-
-                    <#--  Publication professions  -->
-                    <#if document.publicationProfessions?has_content>
-                        <div class="hee-card--details__item">
-                            <span>Professions:</span>
-                            <#if publicationListingPageURL?has_content>
-                                <#list document.publicationProfessions as profession>
-                                    <a href=${publicationListingPageURL}?publicationProfession=${profession}>${publicationProfessionMap[profession]}</a><#sep>, </#sep>
-                                </#list>
-                            <#else>
-                                <#list document.publicationProfessions as profession>
-                                    ${publicationProfessionMap[profession]}<#sep>, </#sep>
-                                </#list>
-                            </#if>
-                        </div>
-                        </#if>
-
-                    <#--  Publication topics  -->
-                    <#if document.publicationTopics?has_content>
-                        <div class="hee-card--details__item">
-                            <span>Topics:</span>
-                            <#if publicationListingPageURL?has_content>
-                                <#list document.publicationTopics as topic>
-                                    <a href=${publicationListingPageURL}?publicationTopic=${topic}>${publicationTopicMap[topic]}</a><#sep>, </#sep>
-                                </#list>
-                            <#else>
-                                <#list document.publicationTopics as topic>
-                                    ${publicationTopicMap[topic]}<#sep>, </#sep>
-                                </#list>
-                            </#if>
-                        </div>
-                    </#if>
+                    <@publicationPartialInfo publicationListingPageURL=publicationListingPageURL
+                        globalPublicationTypeMap=globalPublicationTypeMap
+                        globalProfessionsMap=globalProfessionsMap
+                        globalTopicsMap=globalTopicsMap/>
 
                     <#--  Read time  -->
                     <div class="hee-card--details__item">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/report-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/report-main.ftl
@@ -2,6 +2,8 @@
 <#include "../../include/imports.ftl">
 <#include "../../include/page-meta-data.ftl">
 <#import "../macros/components.ftl" as hee>
+<#include "../macros/back-link.ftl">
+<#include "../macros/publication-partial-info.ftl">
 <#include "../utils/date-util.ftl">
 
 <@hst.setBundle basename="uk.nhs.hee.web.global"/>
@@ -148,49 +150,11 @@
                         </div>
                     </#if>
 
-
                     <#if landingPage??>
-                        <#--  Publication type  -->
-                        <div class="hee-card--details__item">
-                            <span>Publication Type:</span>
-                            <#if publicationListingPageURL?has_content>
-                                <a href=${publicationListingPageURL}?publicationType=${landingPage.publicationType}>${publicationTypeMap[landingPage.publicationType]}</a>
-                            <#else>
-                                ${publicationTypeMap[landingPage.publicationType]}
-                            </#if>
-                        </div>
-
-                        <#--  Publication professions  -->
-                        <#if landingPage.publicationProfessions?has_content>
-                            <div class="hee-card--details__item">
-                                <span>Professions:</span>
-                                <#if publicationListingPageURL?has_content>
-                                    <#list landingPage.publicationProfessions as profession>
-                                        <a href=${publicationListingPageURL}?publicationProfession=${profession}>${publicationProfessionMap[profession]}</a><#sep>, </#sep>
-                                    </#list>
-                                <#else>
-                                    <#list landingPage.publicationProfessions as profession>
-                                        ${publicationProfessionMap[profession]}<#sep>, </#sep>
-                                    </#list>
-                                </#if>
-                            </div>
-                        </#if>
-
-                        <#--  Publication topics  -->
-                        <#if landingPage.publicationTopics?has_content>
-                            <div class="hee-card--details__item">
-                                <span>Topics:</span>
-                                <#if publicationListingPageURL?has_content>
-                                    <#list landingPage.publicationTopics as topic>
-                                        <a href=${publicationListingPageURL}?publicationTopic=${topic}>${publicationTopicMap[topic]}</a><#sep>, </#sep>
-                                    </#list>
-                                <#else>
-                                    <#list landingPage.publicationTopics as topic>
-                                        ${publicationTopicMap[topic]}<#sep>, </#sep>
-                                    </#list>
-                                </#if>
-                            </div>
-                        </#if>
+                        <@publicationPartialInfo publicationListingPageURL=publicationListingPageURL
+                                            globalPublicationTypeMap=globalPublicationTypeMap
+                                            globalProfessionsMap=globalProfessionsMap
+                                            globalTopicsMap=globalTopicsMap/>
                     </#if>
                 </div>
                 <#--  Publication Info: END  -->

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/list-item.ftl
@@ -270,17 +270,17 @@
 
     <#list items as item>
         <#assign pageURL=getInternalLinkURL(item)>
-
         <#if pageURL != pageNotFoundURL>
             <div class="hee-listing-item">
                 <#--  Title  -->
                 <h3><a href="${pageURL}">${item.title}</a></h3>
 
-                <#--  Publication details: START   -->
                 <div class="hee-listing-item__details">
-                    <@listItemRow key="${publicationTypeLabel}">
-                        ${publicationTypeMap[item.publicationType]}
-                    </@listItemRow>
+                    <#if item.publicationTypeClassifiable?has_content>
+                        <@listItemRow key="${publicationTypeLabel}">
+                            ${publicationTypeMap[item.publicationTypeClassifiable[0]]}
+                        </@listItemRow>
+                    </#if>
 
                     <@listItemRow key="${publishDateLabel}">
                         ${item.publicationDate.time?string['dd MMMM yyyy']}

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/publication-partial-info.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/publication-partial-info.ftl
@@ -1,0 +1,46 @@
+<#macro publicationPartialInfo publicationListingPageURL globalPublicationTypeMap globalProfessionsMap globalTopicsMap>
+    <#--  Publication type  -->
+    <#if globalPublicationTypeMap?has_content>
+        <div class="hee-card--details__item">
+            <span>Publication type:</span>
+            <#if publicationListingPageURL?has_content>
+                <a href=${publicationListingPageURL}?publicationType=${globalPublicationTypeMap?keys[0]}>${globalPublicationTypeMap?values[0]}</a>
+            <#else>
+                ${globalPublicationTypeMap?values[0]}
+            </#if>
+        </div>
+    </#if>
+
+    <#--  Publication professions  -->
+    <#if globalProfessionsMap?has_content>
+        <div class="hee-card--details__item">
+            <span>Professions:</span>
+            <#if publicationListingPageURL?has_content>
+                <#list globalProfessionsMap as profession, value>
+                    <a href=${publicationListingPageURL}?publicationProfession=${profession}>${value}</a><#sep>, </#sep>
+                </#list>
+            <#else>
+                <#list globalProfessionsMap as profession>
+                    ${profession}<#sep>, </#sep>
+                </#list>
+            </#if>
+        </div>
+    </#if>
+
+    <#--  Publication topics  -->
+    <#if globalTopicsMap?has_content>
+        <div class="hee-card--details__item">
+            <span>Topics:</span>
+            <#if publicationListingPageURL?has_content>
+                <#list globalTopicsMap as topic, value>
+                    <a href=${publicationListingPageURL}?publicationTopic=${topic}>${value}</a><#sep>, </#sep>
+                </#list>
+            <#else>
+                <#list globalTopicsMap as topic>
+                    ${topic}<#sep>, </#sep>
+                </#list>
+            </#if>
+        </div>
+    </#if>
+
+</#macro>

--- a/site/components/pom.xml
+++ b/site/components/pom.xml
@@ -82,6 +82,18 @@
       <artifactId>hippo-addon-urlrewriter-site-dependencies</artifactId>
       <type>pom</type>
     </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-hst-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-hstclient</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/PublicationLandingPage.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/PublicationLandingPage.java
@@ -3,10 +3,8 @@ package uk.nhs.hee.web.beans;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 import org.hippoecm.hst.content.beans.Node;
 import java.util.Calendar;
-import uk.nhs.hee.web.beans.PageLastNextReview;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import java.util.List;
-import org.hippoecm.hst.content.beans.standard.HippoResourceBean;
 
 /** 
  * TODO: Beanwriter: Failed to create getter for node type: hippo:compound
@@ -34,19 +32,14 @@ public class PublicationLandingPage extends BaseDocument {
         return getSingleProperty("hee:publicationDate");
     }
 
-    @HippoEssentialsGenerated(internalName = "hee:publicationType")
-    public String getPublicationType() {
-        return getSingleProperty("hee:publicationType");
+    @HippoEssentialsGenerated(internalName = "hee:publicationTypeClassifiable")
+    public String[] getPublicationTypeClassifiable() {
+        return getMultipleProperty("hee:publicationTypeClassifiable");
     }
 
-    @HippoEssentialsGenerated(internalName = "hee:publicationTopics")
-    public String[] getPublicationTopics() {
-        return getMultipleProperty("hee:publicationTopics");
-    }
-
-    @HippoEssentialsGenerated(internalName = "hee:publicationProfessions")
-    public String[] getPublicationProfessions() {
-        return getMultipleProperty("hee:publicationProfessions");
+    @HippoEssentialsGenerated(internalName = "hee:publicationTopicsClassifiable")
+    public String[] getPublicationTopicsClassifiable() {
+        return getMultipleProperty("hee:publicationTopicsClassifiable");
     }
 
     @HippoEssentialsGenerated(internalName = "hee:readTime")
@@ -86,5 +79,10 @@ public class PublicationLandingPage extends BaseDocument {
     @HippoEssentialsGenerated(internalName = "hee:otherFormatsEmail")
     public String getOtherFormatsEmail() {
         return getSingleProperty("hee:otherFormatsEmail");
+    }
+
+    @HippoEssentialsGenerated(internalName = "hippotaxonomy:keys")
+    public String[] getKeys() {
+        return getMultipleProperty("hippotaxonomy:keys");
     }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/components/Model.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/Model.java
@@ -51,6 +51,21 @@ public enum Model {
     NEWSLETTER_PROFESSION_MAP("newsletterProfessionMap"),
 
     /**
+     * Model key for Global Profession Taxonomy Map
+     */
+    GLOBAL_PROFESSION_MAP("globalProfessionsMap"),
+
+    /**
+     * Model key for Global Publication Type Taxonomy Map
+     */
+    GLOBAL_PUBLICATION_TYPE_MAP("globalPublicationTypeMap"),
+
+    /**
+     * Model key for Global Publication Topics Taxonomy Map
+     */
+    GLOBAL_TOPICS_MAP("globalTopicsMap"),
+
+    /**
      * Model key for Topic Valuelist map
      */
     TOPIC_MAP("topicMap"),

--- a/site/components/src/main/java/uk/nhs/hee/web/components/PublicationLandingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/PublicationLandingPageComponent.java
@@ -6,10 +6,12 @@ import org.hippoecm.hst.core.component.HstResponse;
 import org.hippoecm.hst.core.parameters.ParametersInfo;
 import org.hippoecm.hst.core.request.HstRequestContext;
 import org.onehippo.cms7.essentials.components.EssentialsDocumentComponent;
+import uk.nhs.hee.web.beans.PublicationLandingPage;
 import uk.nhs.hee.web.components.info.PublicationLandingPageComponentInfo;
-import uk.nhs.hee.web.repository.ValueListIdentifier;
 import uk.nhs.hee.web.utils.HstUtils;
-import uk.nhs.hee.web.utils.ValueListUtils;
+import uk.nhs.hee.web.utils.ReportAndPublicationUtils;
+
+import java.util.Locale;
 
 /**
  * Component class for {@code hee:publicationLandingPage} document type pages.
@@ -20,23 +22,22 @@ public class PublicationLandingPageComponent extends EssentialsDocumentComponent
     @Override
     public void doBeforeRender(final HstRequest request, final HstResponse response) {
         super.doBeforeRender(request, response);
-        addPublicationTypeTopicAndProfessionMapsToModel(request);
+        final PublicationLandingPage publicationLandingPage = request.getModel(REQUEST_ATTR_DOCUMENT);
         addPublicationListingPageURLToModel(request);
+
+        addTaxonomyFieldsToMap(request, publicationLandingPage);
     }
 
     /**
-     * Adds Publication type, topic and profession value-list maps to model.
+     * Convenience method for loading the map
      *
-     * @param request the {@link HstRequest} instance.
+     * @param request
+     * @param publicationLandingPage
      */
-    private void addPublicationTypeTopicAndProfessionMapsToModel(final HstRequest request) {
-        // Adds publications topic and profession value-lists
-        request.setModel("publicationTopicMap",
-                ValueListUtils.getValueListMap(ValueListIdentifier.PUBLICATION_TOPICS.getName()));
-        request.setModel("publicationProfessionMap",
-                ValueListUtils.getValueListMap(ValueListIdentifier.PUBLICATION_PROFESSIONS.getName()));
-        request.setModel("publicationTypeMap",
-                ValueListUtils.getValueListMap(ValueListIdentifier.PUBLICATION_TYPES.getName()));
+    private void addTaxonomyFieldsToMap(final HstRequest request, PublicationLandingPage publicationLandingPage) {
+        final Locale locale = request.getLocale();
+
+        new ReportAndPublicationUtils().addPublicationLandingPageTaxonomyFieldsToModel(request, locale, publicationLandingPage);
     }
 
     /**
@@ -59,6 +60,5 @@ public class PublicationLandingPageComponent extends EssentialsDocumentComponent
                 "publicationListingPageURL",
                 HstUtils.getURLByBean(hstRequestContext, publicationListingPageBean, false));
     }
-
 }
 

--- a/site/components/src/main/java/uk/nhs/hee/web/components/PublicationListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/PublicationListingPageComponent.java
@@ -8,12 +8,20 @@ import org.hippoecm.hst.content.beans.standard.HippoFolderBean;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
 import org.hippoecm.hst.core.parameters.ParametersInfo;
+import org.hippoecm.hst.site.HstServices;
 import org.hippoecm.hst.util.ContentBeanUtils;
+import org.onehippo.taxonomy.api.Taxonomies;
+import org.onehippo.taxonomy.api.Taxonomy;
+import org.onehippo.taxonomy.api.TaxonomyManager;
 import uk.nhs.hee.web.components.info.PublicationListingPageComponentInfo;
+import uk.nhs.hee.web.constants.HEETaxonomy;
 import uk.nhs.hee.web.repository.HEEField;
-import uk.nhs.hee.web.repository.ValueListIdentifier;
 import uk.nhs.hee.web.utils.HstUtils;
-import uk.nhs.hee.web.utils.ValueListUtils;
+import uk.nhs.hee.web.utils.TaxonomyTemplateUtils;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -49,36 +57,33 @@ public class PublicationListingPageComponent extends ListingPageComponent {
                 HstUtils.getQueryParameterValues(request, QUERY_PARAM_PUBLICATION_PROFESSION));
         request.setModel("selectedSortOrder", getSelectedSortOrder(request));
 
-        Map<String, String> publicationTypeMap=  ValueListUtils.getValueListMap(ValueListIdentifier.PUBLICATION_TYPES.getName());
-        Map<String, String> publicationTopicMap = ValueListUtils.getValueListMap(ValueListIdentifier.PUBLICATION_TOPICS.getName());
-        Map<String, String> publicationProfessionMap = ValueListUtils.getValueListMap(ValueListIdentifier.PUBLICATION_PROFESSIONS.getName());
-        // Adds all publications filters
-        request.setModel("publicationTypeMap",
-                publicationTypeMap.entrySet()
-                        .stream()
-                        .sorted(Map.Entry.comparingByValue())
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey,
-                                Map.Entry::getValue,
-                                (oldValue, newValue) -> oldValue, LinkedHashMap::new)));
-        request.setModel("publicationTopicMap",
-                publicationTopicMap.entrySet()
-                        .stream().sorted(Map.Entry.comparingByValue())
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey,
-                                Map.Entry::getValue,
-                                (oldValue, newValue) -> oldValue, LinkedHashMap::new)));
-        request.setModel("publicationProfessionMap",
-                publicationProfessionMap.entrySet()
-                        .stream().sorted(Map.Entry.comparingByValue())
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey,
-                                Map.Entry::getValue,
-                                (oldValue, newValue) -> oldValue, LinkedHashMap::new)));
+        loadTaxonomiesIntoKeyValueMaps(request);
 
         // Adds publication filter facets
         addPublicationFilterFacetsToModel(request);
     }
+
+    private void loadTaxonomiesIntoKeyValueMaps(HstRequest request) {
+        final TaxonomyManager taxonomyManager = HstServices.getComponentManager()
+                .getComponent(TaxonomyManager.class.getSimpleName(),"org.onehippo.taxonomy.contentbean");
+        final Taxonomies taxonomies = taxonomyManager.getTaxonomies();
+        final Locale locale = request.getLocale();
+
+        request.setModel("publicationProfessionMap", getMapFor(taxonomies, HEETaxonomy.HEE_GLOBAL_PROFESSIONS.getName(), locale));
+        request.setModel("publicationTopicMap", getMapFor(taxonomies, HEETaxonomy.HEE_GLOBAL_TOPICS.getName(), locale));
+        request.setModel("publicationTypeMap", getMapFor(taxonomies, HEETaxonomy.HEE_GLOBAL_PUBLICATION_TYPES.getName(), locale));
+    }
+
+    private Map<String, String> getMapFor(Taxonomies taxonomies, String taxonomyName, Locale locale) {
+        Taxonomy taxonomy = taxonomies.getTaxonomy(taxonomyName);
+
+        if (taxonomy != null) {
+            return TaxonomyTemplateUtils.getTaxonomyAsMap(taxonomy, locale);
+        } else {
+            return new HashMap<>();
+        }
+    }
+
 
     /**
      * Builds Query {@link Filter} for publication listing.
@@ -93,18 +98,18 @@ public class PublicationListingPageComponent extends ListingPageComponent {
         return createOrFilter(
                 query,
                 HstUtils.getQueryParameterValues(request, QUERY_PARAM_PUBLICATION_TYPE),
-                HEEField.PUBLICATION_TYPE.getName()
+                HEEField.PUBLICATION_TYPE_CLASSIFIABLE.getName()
         ).addAndFilter(
                 createOrFilter(
                     query,
                     HstUtils.getQueryParameterValues(request, QUERY_PARAM_PUBLICATION_TOPIC),
-                    HEEField.PUBLICATION_TOPICS.getName()
+                    HEEField.PUBLICATION_TOPICS_CLASSIFIABLE.getName()
                 )
         ).addAndFilter(
                 createOrFilter(
                         query,
                         HstUtils.getQueryParameterValues(request, QUERY_PARAM_PUBLICATION_PROFESSION),
-                        HEEField.PUBLICATION_PROFESSIONS.getName()
+                        HEEField.PUBLICATION_PROFESSIONS_CLASSIFIABLE.getName()
                 )
         );
     }
@@ -133,11 +138,11 @@ public class PublicationListingPageComponent extends ListingPageComponent {
         }
 
         for (final HippoFolderBean folder : facetNavigation.getFolders()) {
-            if (HEEField.PUBLICATION_TYPE.getName().equals(folder.getName())) {
+            if (HEEField.PUBLICATION_TYPE_CLASSIFIABLE.getName().equals(folder.getName())) {
                 request.setModel("publicationTypeFacet", folder);
-            } else if (HEEField.PUBLICATION_TOPICS.getName().equals(folder.getName())) {
+            } else if (HEEField.PUBLICATION_TOPICS_CLASSIFIABLE.getName().equals(folder.getName())) {
                 request.setModel("publicationTopicFacet", folder);
-            } else if (HEEField.PUBLICATION_PROFESSIONS.getName().equals(folder.getName())) {
+            } else if (HEEField.PUBLICATION_PROFESSIONS_CLASSIFIABLE.getName().equals(folder.getName())) {
                 request.setModel("publicationProfessionFacet", folder);
             }
         }

--- a/site/components/src/main/java/uk/nhs/hee/web/constants/HEETaxonomy.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/constants/HEETaxonomy.java
@@ -1,0 +1,30 @@
+package uk.nhs.hee.web.constants;
+
+public enum HEETaxonomy {
+
+    HEE_GLOBAL_PROFESSIONS ("hee-global-professions"),
+
+    HEE_GLOBAL_TOPICS ("hee-global-topics"),
+
+    HEE_GLOBAL_PUBLICATION_TYPES ("hee-global-publication-types");
+
+    private final String name;
+
+    /**
+     * Constructor that initialises the name of HEE taxonomies
+     *
+     * @param name the name of HEE taxonomy
+     */
+    HEETaxonomy(final String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the name of HEE taxonomy
+     *
+     * @return the name of HEE taxonomy.
+     */
+    public String getName() {
+        return this.name;
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/repository/HEEField.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/repository/HEEField.java
@@ -41,19 +41,19 @@ public enum HEEField {
     PUBLICATION_DATE("hee:publicationDate"),
 
     /**
-     * {@code publicationType} field/property.
+     * {@code publicationType} field/property (maps to a taxonomy entry)
      */
-    PUBLICATION_TYPE("hee:publicationType"),
+    PUBLICATION_TYPE_CLASSIFIABLE("hee:publicationTypeClassifiable"),
 
     /**
      * {@code publicationTopics} field/property.
      */
-    PUBLICATION_TOPICS("hee:publicationTopics"),
+    PUBLICATION_TOPICS_CLASSIFIABLE("hee:publicationTopicsClassifiable"),
 
     /**
      * {@code publicationProfessions} field/property.
      */
-    PUBLICATION_PROFESSIONS("hee:publicationProfessions"),
+    PUBLICATION_PROFESSIONS_CLASSIFIABLE("hippotaxonomy:keys"),
 
     /**
      * {@code topics} field/property.

--- a/site/components/src/main/java/uk/nhs/hee/web/services/FeaturedContentBlockService.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/services/FeaturedContentBlockService.java
@@ -79,7 +79,7 @@ public class FeaturedContentBlockService {
                                 queryAndFiltersUtils.createOrFilter(
                                         query,
                                         Collections.singletonList(featuredContentBlock.getPublicationType()),
-                                        HEEField.PUBLICATION_TYPE.getName()
+                                        HEEField.PUBLICATION_TYPE_CLASSIFIABLE.getName()
                                 )
                         );
                     }
@@ -89,7 +89,7 @@ public class FeaturedContentBlockService {
                                 queryAndFiltersUtils.createOrFilter(
                                         query,
                                         Arrays.asList(featuredContentBlock.getTopics()),
-                                        HEEField.PUBLICATION_TOPICS.getName()
+                                        HEEField.PUBLICATION_TOPICS_CLASSIFIABLE.getName()
                                 )
                         );
                     }
@@ -99,7 +99,7 @@ public class FeaturedContentBlockService {
                                 queryAndFiltersUtils.createOrFilter(
                                         query,
                                         Arrays.asList(featuredContentBlock.getProfessions()),
-                                        HEEField.PUBLICATION_PROFESSIONS.getName()
+                                        HEEField.PUBLICATION_PROFESSIONS_CLASSIFIABLE.getName()
                                 )
                         );
                     }

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/ReportAndPublicationUtils.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/ReportAndPublicationUtils.java
@@ -4,11 +4,24 @@ import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;
 import org.hippoecm.hst.content.beans.query.exceptions.QueryException;
 import org.hippoecm.hst.content.beans.standard.HippoDocumentBean;
+import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.request.HstRequestContext;
+import org.hippoecm.hst.site.HstServices;
 import org.hippoecm.hst.util.ContentBeanUtils;
+import org.onehippo.taxonomy.api.Taxonomies;
+import org.onehippo.taxonomy.api.Taxonomy;
+import org.onehippo.taxonomy.api.TaxonomyManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.nhs.hee.web.beans.PublicationLandingPage;
+import uk.nhs.hee.web.components.Model;
+import uk.nhs.hee.web.constants.HEETaxonomy;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.jcr.RepositoryException;
 
@@ -41,5 +54,69 @@ public class ReportAndPublicationUtils {
                     "related to the Publication (Report) Page '{}' ", e.getMessage(), reportBean.getPath(), e);
         }
         return null;
+    }
+
+    /**
+     * Load values from the PublicationLandingPage and set up the maps which hold their keys/values
+     *
+     * Once found, the maps are added to the request object and can be used in the template
+     * @param request
+     * @param locale
+     * @param publicationLandingPage
+     */
+    public void addPublicationLandingPageTaxonomyFieldsToModel(final HstRequest request, final Locale locale, PublicationLandingPage publicationLandingPage) {
+        final TaxonomyManager taxonomyManager = HstServices.getComponentManager()
+                .getComponent(TaxonomyManager.class.getSimpleName(),"org.onehippo.taxonomy.contentbean");
+        final Taxonomies taxonomies = taxonomyManager.getTaxonomies();
+
+        addGlobalTaxonomyMapIntoModel(request, locale, taxonomies, publicationLandingPage);
+        addPublicationTypeMapIntoModel(request, locale, taxonomies, publicationLandingPage);
+        addPublicationTopicsMapIntoModel(request, locale, taxonomies, publicationLandingPage);
+    }
+
+    private void addGlobalTaxonomyMapIntoModel(HstRequest request, Locale locale, Taxonomies taxonomies, PublicationLandingPage publicationLandingPage) {
+        final String[] selectedTerms = publicationLandingPage.getKeys();
+
+        Map<String, String> keysAndCats = addTaxonomyKeysAndValues(locale, taxonomies.getTaxonomy(HEETaxonomy.HEE_GLOBAL_PROFESSIONS.getName()), selectedTerms);
+        if (keysAndCats != null) {
+            request.setModel(Model.GLOBAL_PROFESSION_MAP.getKey(), keysAndCats);
+        }
+    }
+
+    private void addPublicationTypeMapIntoModel(HstRequest request, Locale locale, Taxonomies taxonomies, PublicationLandingPage landingPage) {
+        final String[] selectedTerms = landingPage.getPublicationTypeClassifiable();
+
+        Map<String, String> keysAndCats = addTaxonomyKeysAndValues(locale, taxonomies.getTaxonomy(HEETaxonomy.HEE_GLOBAL_PUBLICATION_TYPES.getName()), selectedTerms);
+        if (keysAndCats != null) {
+            request.setModel(Model.GLOBAL_PUBLICATION_TYPE_MAP.getKey(), keysAndCats);
+        }
+    }
+
+    private void addPublicationTopicsMapIntoModel(HstRequest request, Locale locale, Taxonomies taxonomies, PublicationLandingPage landingPage) {
+        final String[] selectedTerms = landingPage.getPublicationTopicsClassifiable();
+
+        Map<String, String> keysAndCats = addTaxonomyKeysAndValues(locale, taxonomies.getTaxonomy(HEETaxonomy.HEE_GLOBAL_TOPICS.getName()), selectedTerms);
+        if (keysAndCats != null) {
+            request.setModel(Model.GLOBAL_TOPICS_MAP.getKey(), keysAndCats);
+        }
+    }
+
+    /**
+     * Given a taxonomy, in a specific locale, and a set of keys, go off and find the values for those keys
+     * and send back a Map that holds those key-value pairs
+     * @param locale
+     * @param taxonomy
+     * @param selectedKeys
+     * @return
+     */
+    private Map<String, String> addTaxonomyKeysAndValues(Locale locale, Taxonomy taxonomy, String[] selectedKeys) {
+        if (selectedKeys != null ) {
+            return Arrays
+                    .stream(selectedKeys)
+                    .collect(Collectors.toMap(key -> key,
+                            key -> taxonomy.getCategoryByKey(key).getInfo(locale).getName()));
+        }
+
+        return new HashMap<>();
     }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/utils/TaxonomyTemplateUtils.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/utils/TaxonomyTemplateUtils.java
@@ -1,0 +1,46 @@
+package uk.nhs.hee.web.utils;
+
+import org.onehippo.taxonomy.api.Category;
+import org.onehippo.taxonomy.api.Taxonomy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * A class to support the loaing oif taxonomy details into the display template
+ */
+public class TaxonomyTemplateUtils {
+    /**
+     * This initiates the loading of a map from the named taxonomy
+     * @param taxonomy that we are reading
+     * @param locale that we use to enable us to find the textual value for a key
+     * @return a {@link Map} with keys and values for use in the template
+     */
+    public static Map<String, String> getTaxonomyAsMap(Taxonomy taxonomy, Locale locale) {
+        List<? extends Category> categories = taxonomy.getCategories();
+        Map<String, String> catsMap = new HashMap<>();
+
+        getChildren(categories, catsMap, locale);
+        return catsMap;
+    }
+
+    /**
+     * This is a recursively called function that will iterate through a category's chiuldren and load all keys and values into the map
+     * @param categories
+     * @param catsMap
+     * @param locale
+     */
+    private static void getChildren(List<? extends Category> categories, Map<String, String> catsMap, Locale locale) {
+        for (Category category : categories) {
+            String name = category.getInfo(locale).getName();
+            String key = category.getKey();
+            catsMap.put(key, name);
+            List<? extends Category> childCats = category.getChildren();
+            if (childCats != null && childCats.size() > 0) {
+                getChildren(childCats, catsMap, locale);
+            }
+        }
+    }
+}

--- a/site/components/src/test/java/uk/nhs/hee/web/repository/HEEFieldTest.java
+++ b/site/components/src/test/java/uk/nhs/hee/web/repository/HEEFieldTest.java
@@ -16,9 +16,9 @@ public class HEEFieldTest {
         assertThat(HEEField.IMPACT_GROUP.getName()).isEqualTo("hee:impactGroup");
         assertThat(HEEField.LISTING_TYPE.getName()).isEqualTo("hee:listingPageType");
         assertThat(HEEField.PUBLICATION_DATE.getName()).isEqualTo("hee:publicationDate");
-        assertThat(HEEField.PUBLICATION_TYPE.getName()).isEqualTo("hee:publicationType");
-        assertThat(HEEField.PUBLICATION_TOPICS.getName()).isEqualTo("hee:publicationTopics");
-        assertThat(HEEField.PUBLICATION_PROFESSIONS.getName()).isEqualTo("hee:publicationProfessions");
+        assertThat(HEEField.PUBLICATION_TYPE_CLASSIFIABLE.getName()).isEqualTo("hee:publicationTypeClassifiable");
+        assertThat(HEEField.PUBLICATION_TOPICS_CLASSIFIABLE.getName()).isEqualTo("hee:publicationTopicsClassifiable");
+        assertThat(HEEField.PUBLICATION_PROFESSIONS_CLASSIFIABLE.getName()).isEqualTo("hippotaxonomy:keys");
         assertThat(HEEField.TOPICS.getName()).isEqualTo("hee:topics");
     }
 }


### PR DESCRIPTION
Bringing across changes that we tested in NWPS-1484 

- Extended the Bloomreach taxonomy component so that it can now accept a ${channel} identifier in a taxonomy list
- Added a button.text property to the individual taxonomy to optionally show custom text on the button that invokes the picker dialog
- Added a multiple property to the individual taxonomy to explicitly call out a field to have multiple terms selected in the picker dialog
Note that the publicationType, publicattionTopics and publicationProfessions fields have been removed and replaced by counterparts which use taxonomies