### PR TITLE
[NWPS-1374] Link picker configuration update for `assetData` field of `assetResource` compound type

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/assetResource.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/assetResource.yaml
@@ -104,3 +104,4 @@ definitions:
               base.path: /content/assets
               nodetypes: ['hippogallery:exampleAssetSet']
               last.visited.enabled: 'true'
+              cluster.name: cms-pickers/assets


### PR DESCRIPTION
Link picker configuration to choose only assets for the `assetData` field of `assetResource` compound type:

![assets-only-link-picker](https://github.com/Health-Education-England/hee-cms-platform/assets/35143542/f7c4624b-f4fe-4b0b-9688-f4267a3ecfd7)
