### PR TITLE
NWPS-1617-be-featured-content-display-on-other-pages-as-movable-blocks

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/blogPage.yaml
@@ -287,7 +287,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:anchorLinks,hee:blockLinksReference,hee:contentCards,hippostd:html,hee:googleMapReference,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:quoteReference,hee:tableReference,hee:expanderTableReference,hee:tabsReference,hee:richTextReference,hee:warningCalloutReference
+            compoundList: hee:anchorLinks,hee:blockLinksReference,hee:contentCards,hee:featuredContentReference,hippostd:html,hee:googleMapReference,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:quoteReference,hee:tableReference,hee:expanderTableReference,hee:tabsReference,hee:richTextReference,hee:warningCalloutReference
             contentPickerType: links
             field: contentBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/featuredContentReference.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/featuredContentReference.yaml
@@ -23,6 +23,7 @@ definitions:
             hipposysedit:path: hee:featuredContentBlock
             hipposysedit:primary: false
             hipposysedit:type: hippo:mirror
+            hipposysedit:validators: [required]
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
@@ -198,7 +198,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:ActionLink,hee:anchorLinks,hee:appliesToBoxReference,hee:blockLinksReference,hee:buttonReference,hee:contentCards,hee:statementCardReference,hee:detailsReference,hee:expanderGroupReference,hippostd:html,hee:googleMapReference,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:newsletterSubscribeFormReference,hee:quoteReference,hee:navMap,hee:tableReference,hee:expanderTableReference,hee:tabsReference,hee:richTextReference,hee:warningCalloutReference
+            compoundList: hee:ActionLink,hee:anchorLinks,hee:appliesToBoxReference,hee:blockLinksReference,hee:buttonReference,hee:contentCards,hee:statementCardReference,hee:detailsReference,hee:expanderGroupReference,hee:featuredContentReference,hippostd:html,hee:googleMapReference,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:newsletterSubscribeFormReference,hee:quoteReference,hee:navMap,hee:tableReference,hee:expanderTableReference,hee:tabsReference,hee:richTextReference,hee:warningCalloutReference
             contentPickerType: links
             field: contentBlocks
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
@@ -294,7 +294,7 @@ definitions:
           /contentBlocks:
             jcr:primaryType: frontend:plugin
             caption: Main content objects
-            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contentCards,hee:statementCardReference,hippostd:html,hee:googleMapReference,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:quoteReference,hee:tableReference,hee:expanderTableReference,hee:tabsReference,hee:richTextReference,hee:warningCalloutReference
+            compoundList: hee:ActionLink,hee:anchorLinks,hee:blockLinksReference,hee:contentCards,hee:statementCardReference,hee:featuredContentReference,hippostd:html,hee:googleMapReference,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:quoteReference,hee:tableReference,hee:expanderTableReference,hee:tabsReference,hee:richTextReference,hee:warningCalloutReference
             contentPickerType: links
             field: contentBlocks
             hint: ''

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/blogpost-main.ftl
@@ -119,6 +119,9 @@
                         <#case "uk.nhs.hee.web.beans.WarningCalloutReference">
                             <@hee.warningCallout block=block/>
                             <#break>
+                        <#case "uk.nhs.hee.web.beans.FeaturedContentReference">
+                            <@hee.featuredContent block=block/>
+                            <#break>
                         <#default>
                     </#switch>
                 </#list>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/news-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/news-main.ftl
@@ -126,6 +126,9 @@
                             <#case "uk.nhs.hee.web.beans.StatementCardReference">
                                 <@hee.statementCard block=block/>
                                 <#break>
+                            <#case "uk.nhs.hee.web.beans.FeaturedContentReference">
+                                <@hee.featuredContent block=block/>
+                                <#break>
                             <#default>
                         </#switch>
                     </#list>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
@@ -107,6 +107,9 @@
                                     <#case "uk.nhs.hee.web.beans.GoogleMapReference">
                                         <@hee.googleMap block=block/>
                                         <#break>
+                                    <#case "uk.nhs.hee.web.beans.FeaturedContentReference">
+                                        <@hee.featuredContent block=block/>
+                                        <#break>
                                     <#default>
                                 </#switch>
                             </#list>

--- a/site/components/src/main/java/uk/nhs/hee/web/components/BlogPostComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/BlogPostComponent.java
@@ -11,6 +11,7 @@ import uk.nhs.hee.web.beans.BlogPost;
 import uk.nhs.hee.web.components.info.BlogPostComponentInfo;
 import uk.nhs.hee.web.repository.ValueListIdentifier;
 import uk.nhs.hee.web.services.TableComponentService;
+import uk.nhs.hee.web.services.FeaturedContentBlockService;
 import uk.nhs.hee.web.utils.ContentBlocksUtils;
 import uk.nhs.hee.web.utils.DocumentUtils;
 import uk.nhs.hee.web.utils.HstUtils;
@@ -43,6 +44,7 @@ public class BlogPostComponent extends EssentialsDocumentComponent {
             // addBlogCommentsToModel(request, blogPost);
 
             request.setAttribute("tableComponentService", new TableComponentService());
+            request.setModel("featuredContentBlockService", new FeaturedContentBlockService());
         }
     }
 

--- a/site/components/src/main/java/uk/nhs/hee/web/components/GuidanceComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/GuidanceComponent.java
@@ -8,6 +8,7 @@ import org.onehippo.cms7.essentials.components.EssentialsDocumentComponent;
 import uk.nhs.hee.web.beans.Guidance;
 import uk.nhs.hee.web.components.info.GuidanceComponentInfo;
 import uk.nhs.hee.web.services.TableComponentService;
+import uk.nhs.hee.web.services.FeaturedContentBlockService;
 import uk.nhs.hee.web.utils.ContentBlocksUtils;
 
 import java.util.List;
@@ -31,6 +32,7 @@ public class GuidanceComponent extends EssentialsDocumentComponent {
             modelToValueListMap.forEach(request::setModel);
 
             request.setAttribute("tableComponentService", new TableComponentService());
+            request.setModel("featuredContentBlockService", new FeaturedContentBlockService());
         }
     }
 }

--- a/site/components/src/main/java/uk/nhs/hee/web/components/NewsComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/NewsComponent.java
@@ -10,6 +10,7 @@ import uk.nhs.hee.web.beans.News;
 import uk.nhs.hee.web.components.info.NewsComponentInfo;
 import uk.nhs.hee.web.repository.ValueListIdentifier;
 import uk.nhs.hee.web.services.TableComponentService;
+import uk.nhs.hee.web.services.FeaturedContentBlockService;
 import uk.nhs.hee.web.utils.ContentBlocksUtils;
 import uk.nhs.hee.web.utils.DocumentUtils;
 import uk.nhs.hee.web.utils.HstUtils;
@@ -41,6 +42,7 @@ public class NewsComponent extends EssentialsDocumentComponent {
             modelToValueListMap.forEach(request::setModel);
 
             request.setAttribute("tableComponentService", new TableComponentService());
+            request.setModel("featuredContentBlockService", new FeaturedContentBlockService());
         }
     }
 


### PR DESCRIPTION
-Add Featured Content Block into SCP, Blogs, News Article Pages main content blocks
-Add the validation that if a featured content block is added, a featured content type needs to be selected