### PR TITLE
[NWPS-1658] Publication landing and single page fixes

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/publicationLandingPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/publicationLandingPage.yaml
@@ -94,7 +94,7 @@ definitions:
             hipposysedit:path: hee:logoGroup
             hipposysedit:primary: false
             hipposysedit:type: hippo:mirror
-          /webPublication:
+          /webPublications:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
             hipposysedit:multiple: true
@@ -340,7 +340,7 @@ definitions:
           /webPublications:
             jcr:primaryType: frontend:plugin
             caption: Publication pages
-            field: webPublication
+            field: webPublications
             hint: Browse to a publication page(s)
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.left.item

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/publications.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/publications.yaml
@@ -1084,6 +1084,7 @@
           jcr:mixinTypes: ['mix:referenceable']
           jcr:uuid: 73871551-caa4-4b43-8501-6ca011e09c7a
           hee:publicationDate: 2022-11-28T00:00:00Z
+          hee:otherFormatsEmail: contact.other_document_formats@hee.nhs.uk
           hee:publicationProfessions: [healthcare_scientists, public_health_professionals]
           hee:publicationTopics: [workforce_planning, workforce_transformation, learning_disability_and_autism,
             pre_employment, careers]
@@ -1136,6 +1137,7 @@
           jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
           jcr:uuid: e1650153-5391-4632-9d27-7965b47ce4fa
           hee:publicationDate: 2022-11-28T00:00:00Z
+          hee:otherFormatsEmail: contact.other_document_formats@hee.nhs.uk
           hee:publicationProfessions: [healthcare_scientists, public_health_professionals]
           hee:publicationTopics: [workforce_planning, workforce_transformation, learning_disability_and_autism,
             pre_employment, careers]
@@ -1188,6 +1190,7 @@
           jcr:mixinTypes: ['mix:referenceable']
           jcr:uuid: 7204e177-bb3e-4ced-be5c-89ae36034711
           hee:publicationDate: 2022-11-28T00:00:00Z
+          hee:otherFormatsEmail: contact.other_document_formats@hee.nhs.uk
           hee:publicationProfessions: [healthcare_scientists, public_health_professionals]
           hee:publicationTopics: [workforce_planning, workforce_transformation, learning_disability_and_autism,
             pre_employment, careers]

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/visual-regression.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/visual-regression.yaml
@@ -3890,6 +3890,7 @@
         jcr:uuid: c1b05457-d9d0-446c-923c-de3f38976415
         hee:hideAuthorContactDetails: false
         hee:publicationDate: 2023-02-08T00:00:00Z
+        hee:otherFormatsEmail: contact.other_document_formats@hee.nhs.uk
         hee:publicationProfessions: [pharmacy_professionals, public_health_professionals,
           medical_doctors]
         hee:publicationTopics: [global_health, health_academia, learning_disability_and_autism]
@@ -3942,6 +3943,7 @@
         jcr:uuid: 4a517cc6-31b3-4622-9ade-2c5468f16519
         hee:hideAuthorContactDetails: false
         hee:publicationDate: 2023-02-08T00:00:00Z
+        hee:otherFormatsEmail: contact.other_document_formats@hee.nhs.uk
         hee:publicationProfessions: [pharmacy_professionals, public_health_professionals,
           medical_doctors]
         hee:publicationTopics: [global_health, health_academia, learning_disability_and_autism]
@@ -3994,6 +3996,7 @@
         jcr:uuid: 41f9016f-fcdf-4336-86ff-39220945154c
         hee:hideAuthorContactDetails: false
         hee:publicationDate: 2023-02-08T00:00:00Z
+        hee:otherFormatsEmail: contact.other_document_formats@hee.nhs.uk
         hee:publicationProfessions: [pharmacy_professionals, public_health_professionals,
           medical_doctors]
         hee:publicationTopics: [global_health, health_academia, learning_disability_and_autism]

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
@@ -123,12 +123,16 @@
                     </#if>
                     <#--  Documents section: END  -->
 
-                    <h2>Other formats</h2>
-                    <div class="hee-publication-doc">
-                        <p>If you need documents in a different format like accessible PDF,&nbsp;
-                        large print, easy read, audio recording or braille please email&nbsp;
-                        <a href="mailto:${document.otherFormatsEmail}">${document.otherFormatsEmail}</a></p>
-                    </div>
+                    <#--  Other document formats: START  -->
+                    <#if document.otherFormatsEmail?has_content>
+                        <h2>Other formats</h2>
+                        <div class="hee-publication-doc">
+                            <p>If you need documents in a different format like accessible PDF,&nbsp;
+                            large print, easy read, audio recording or braille please email&nbsp;
+                            <a href="mailto:${document.otherFormatsEmail}">${document.otherFormatsEmail}</a></p>
+                        </div>
+                    </#if>
+                    <#--  Other document formats: END  -->
 
                     <#--  Author cards  -->
                     <@authorCards authors=document.authors hideAuthorContactDetails=document.hideAuthorContactDetails!false/>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/report-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/report-main.ftl
@@ -76,9 +76,6 @@
                                 <#case "uk.nhs.hee.web.beans.RichTextReference">
                                     <@hst.html hippohtml=block.richTextBlock.html/>
                                     <#break>
-                                <#case "uk.nhs.hee.web.beans.AnchorLinks">
-                                    <@hee.anchorLinks anchor=block/>
-                                    <#break>
                                 <#case "uk.nhs.hee.web.beans.MediaEmbedReference">
                                     <@hee.media media=block/>
                                     <#break>


### PR DESCRIPTION
- Fixed the `Other formats` section on the publication landing page to not display if the `Other formats email` field is empty.
- Updated `webPublications` field name for consistency.
- Removed unused `Anchor links` content block support from the publication single page.