### PR TITLE
[NWPS-1637] Training home page updates

### DIFF
--- a/cms/src/main/resources/ckeditor/styles_without_h1-h2.js
+++ b/cms/src/main/resources/ckeditor/styles_without_h1-h2.js
@@ -1,0 +1,20 @@
+/*
+ * Overrides default style set for 'stylescombo' plugin
+ * in order to remove 'Heading 1' ({ name: 'Heading 1', element: 'h1' })
+ * and 'Heading 2' ({ name: 'Heading 2', element: 'h2' })
+ * from the Styles dropdown.
+ */
+(function () {
+  "use strict";
+
+  CKEDITOR.stylesSet.add('styles_without_h1-h2', [
+	{ name: 'Normal',		element: 'p' },
+	{ name: 'Heading 3',		element: 'h3' },
+	{ name: 'Heading 4',		element: 'h4' },
+	{ name: 'Heading 5',		element: 'h5' },
+	{ name: 'Heading 6',		element: 'h6' },
+	{ name: 'Preformatted Text',element: 'pre' },
+	{ name: 'Address',			element: 'address' }
+  ]);
+
+}());

--- a/cms/src/main/resources/ckeditor/styles_without_h1.js
+++ b/cms/src/main/resources/ckeditor/styles_without_h1.js
@@ -6,7 +6,7 @@
 (function () {
   "use strict";
 
-  CKEDITOR.stylesSet.add('custom_styles', [
+  CKEDITOR.stylesSet.add('styles_without_h1', [
 	{ name: 'Normal',		element: 'p' },
 	{ name: 'Heading 2',		element: 'h2' },
 	{ name: 'Heading 3',		element: 'h3' },

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
@@ -105,7 +105,7 @@ definitions:
       jcr:primaryType: hipposys:resourcebundles
       /en:
         jcr:primaryType: hipposys:resourcebundle
-        jcr:name: Free Text
+        jcr:name: Free text
     /hippo:configuration/hippo:translations/hippo:types/hippogallerypicker:imagelink:
       jcr:primaryType: hipposys:resourcebundles
       /en:
@@ -495,3 +495,8 @@ definitions:
       /en:
         jcr:primaryType: hipposys:resourcebundle
         jcr:name: Add
+    /hippo:configuration/hippo:translations/hippo:types/hee:htmlWithoutHeadingOneAndTwo:
+      jcr:primaryType: hipposys:resourcebundles
+      /en:
+        jcr:primaryType: hipposys:resourcebundle
+        jcr:name: Free text

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee-cms-platform.cnd
@@ -307,3 +307,4 @@
 [hee:warningCalloutReference] > hippo:compound, hippostd:relaxed
   orderable
 
+[hee:htmlWithoutHeadingOneAndTwo] > hippostd:html

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/htmlWithoutHeadingOneAndTwo.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/htmlWithoutHeadingOneAndTwo.yaml
@@ -1,0 +1,88 @@
+definitions:
+  config:
+    /hippo:namespaces/hee/htmlWithoutHeadingOneAndTwo:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      jcr:uuid: 07b38956-659c-4605-9807-f04e0010379a
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        jcr:uuid: 0ddf12a2-cc98-4e33-9875-0c07dde03652
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['hipposysedit:remodel']
+          hipposysedit:uri: http://www.onehippo.org/jcr/hippostd/nt/2.0
+          /content:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: true
+            hipposysedit:path: hippostd:content
+            hipposysedit:primary: true
+            hipposysedit:type: String
+          /links:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:path: '*'
+            hipposysedit:type: hippo:facetselect
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          excluded.image.variants: []
+          frontend:properties: [mode, ckeditor.config.appended.json, ckeditor.config.overlayed.json,
+            htmlprocessor.id, linkpicker.cluster.name, linkpicker.nodetypes, linkpicker.base.uuid,
+            linkpicker.language.context.aware, linkpicker.last.visited.key, linkpicker.last.visited.enabled,
+            linkpicker.last.visited.nodetypes, linkpicker.open.in.new.window.enabled,
+            imagepicker.cluster.name, imagepicker.nodetypes, imagepicker.base.uuid,
+            imagepicker.last.visited.key, imagepicker.last.visited.enabled, imagepicker.last.visited.nodetypes,
+            imagepicker.preferred.image.variant, included.image.variants, excluded.image.variants]
+          frontend:references: [wicket.model, model.compareTo, engine]
+          frontend:services: [wicket.id]
+          htmlprocessor.id: richtext
+          imagepicker.cluster.name: cms-pickers/images
+          imagepicker.last.visited.key: ckeditor-imagepicker
+          imagepicker.last.visited.nodetypes: ['hippostd:gallery']
+          imagepicker.nodetypes: []
+          imagepicker.preferred.image.variant: hippogallery:original
+          included.image.variants: []
+          linkpicker.cluster.name: cms-pickers/documents
+          linkpicker.last.visited.key: ckeditor-linkpicker
+          linkpicker.last.visited.nodetypes: ['hippostd:folder']
+          linkpicker.nodetypes: []
+          linkpicker.open.in.new.window.enabled: true
+          ckeditor.config.overlayed.json: '{ allowedContent: true, forcePasteAsPlainText:
+            false }'
+          ckeditor.config.appended.json: '{ removeButtons: "PickImage,Table", stylesSet:
+            "styles_without_h1-h2:./styles_without_h1-h2.js" }'
+          /root:
+            jcr:primaryType: frontend:plugin
+            browser.id: service.browse
+            ckeditor.config.appended.json: ${ckeditor.config.appended.json}
+            ckeditor.config.overlayed.json: ${ckeditor.config.overlayed.json}
+            diffservice.id: html.diffservice.id
+            htmlprocessor.id: ${htmlprocessor.id}
+            plugin.class: org.hippoecm.frontend.plugins.ckeditor.CKEditorNodePlugin
+            /imagepicker:
+              jcr:primaryType: frontend:pluginconfig
+              base.uuid: ${imagepicker.base.uuid}
+              cluster.name: ${imagepicker.cluster.name}
+              excluded.image.variants: ${excluded.image.variants}
+              included.image.variants: ${included.image.variants}
+              last.visited.enabled: ${imagepicker.last.visited.enabled}
+              last.visited.key: ${imagepicker.last.visited.key}
+              last.visited.nodetypes: ${imagepicker.last.visited.nodetypes}
+              nodetypes: ${imagepicker.nodetypes}
+              preferred.image.variant: ${imagepicker.preferred.image.variant}
+            /linkpicker:
+              jcr:primaryType: frontend:pluginconfig
+              base.uuid: ${linkpicker.base.uuid}
+              cluster.name: ${linkpicker.cluster.name}
+              language.context.aware: ${linkpicker.language.context.aware}
+              last.visited.enabled: ${linkpicker.last.visited.enabled}
+              last.visited.key: ${linkpicker.last.visited.key}
+              last.visited.nodetypes: ${linkpicker.last.visited.nodetypes}
+              nodetypes: ${linkpicker.nodetypes}
+              open.in.new.window.enabled: ${linkpicker.open.in.new.window.enabled}
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
+          hippostd:content: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/tabPanel.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/tabPanel.yaml
@@ -69,6 +69,6 @@ definitions:
             wicket.id: ${cluster.id}.field
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              ckeditor.config.appended.json: '{ stylesSet: "custom_styles:./custom_styles.js"
+              ckeditor.config.appended.json: '{ stylesSet: "styles_without_h1:./styles_without_h1.js"
                 }'
               ckeditor.config.overlayed.json: '{ forcePasteAsPlainText: true }'

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/trainingProgrammesHomepage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/trainingProgrammesHomepage.yaml
@@ -24,14 +24,14 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: String
             hipposysedit:validators: [required]
-          /summary:
+          /subtitle:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: hee:summary
+            hipposysedit:path: hee:subtitle
             hipposysedit:primary: false
-            hipposysedit:type: Text
+            hipposysedit:type: String
             hipposysedit:validators: [required]
           /logoGroup:
             jcr:primaryType: hipposysedit:field
@@ -59,12 +59,12 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: hippogallerypicker:imagelink
             hipposysedit:validators: [required]
-          /caption:
+          /programmeDescription:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: hee:caption
+            hipposysedit:path: hee:programmeDescription
             hipposysedit:primary: false
             hipposysedit:type: Text
           /overview:
@@ -118,7 +118,7 @@ definitions:
           jcr:mixinTypes: ['mix:referenceable']
           jcr:uuid: ccba69dd-0b6d-4110-a85d-8bc3aa360f9e
           hee:addToAZ: false
-          hee:summary: ''
+          hee:subtitle: ''
           hee:title: ''
           hippostd:holder: holder
           hippostd:state: draft
@@ -128,7 +128,7 @@ definitions:
           hippostdpubwf:lastModifiedBy: ''
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
-          hee:caption: ''
+          hee:programmeDescription: ''
           /hee:logoGroup:
             jcr:primaryType: hippo:mirror
             hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
@@ -164,16 +164,16 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               maxlength: '60'
-          /summary:
+          /subtitle:
             jcr:primaryType: frontend:plugin
-            caption: Summary
-            field: summary
+            caption: Page subtitle
+            field: subtitle
             hint: ''
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.left.item
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              maxlength: '185'
+              maxlength: '120'
           /heroImage:
             jcr:primaryType: frontend:plugin
             caption: Hero image
@@ -193,10 +193,10 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               nodetypes: ['hee:logoGroup']
-          /caption:
+          /programmeDescription:
             jcr:primaryType: frontend:plugin
-            caption: Caption
-            field: caption
+            caption: Programme description
+            field: programmeDescription
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.left.item
             /cluster.options:
@@ -209,8 +209,8 @@ definitions:
             wicket.id: ${cluster.id}.left.item
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              ckeditor.config.appended.json: '{ removeButtons: "PickImage,Table,Source"
-                }'
+              ckeditor.config.appended.json: '{ removeButtons: "PickImage,Table,Source",
+                stylesSet: "styles_without_h1-h2:./styles_without_h1-h2.js" }'
           /pathways:
             jcr:primaryType: frontend:plugin
             caption: Pathways

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/trainingProgrammesHomepage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/trainingProgrammesHomepage.yaml
@@ -214,7 +214,7 @@ definitions:
           /pathways:
             jcr:primaryType: frontend:plugin
             caption: Pathways
-            compoundList: hippostd:html,hippogallerypicker:imagelink,hee:richTextReference
+            compoundList: hee:htmlWithoutHeadingOneAndTwo,hippogallerypicker:imagelink,hee:richTextReference
             contentPickerType: links
             field: pathways
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
@@ -225,7 +225,7 @@ definitions:
           /trainingRoutes:
             jcr:primaryType: frontend:plugin
             caption: Training Routes
-            compoundList: hee:ActionLink,hee:blockLinksReference,hippostd:html,hee:richTextReference
+            compoundList: hee:ActionLink,hee:blockLinksReference,hee:htmlWithoutHeadingOneAndTwo,hee:richTextReference
             contentPickerType: links
             field: trainingRoutes
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
@@ -237,7 +237,7 @@ definitions:
           /support:
             jcr:primaryType: frontend:plugin
             caption: Support
-            compoundList: hee:ActionLink,hippostd:html,hee:richTextReference
+            compoundList: hee:ActionLink,hee:htmlWithoutHeadingOneAndTwo,hee:richTextReference
             contentPickerType: links
             field: support
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hippostd/html.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hippostd/html.yaml
@@ -2,6 +2,6 @@ definitions:
   config:
     /hippo:namespaces/hippostd/html/editor:templates/_default_:
       ckeditor.config.appended.json: '{ removeButtons: "PickImage,Table", stylesSet:
-        "custom_styles:./custom_styles.js" }'
+        "styles_without_h1:./styles_without_h1.js" }'
       ckeditor.config.overlayed.json: '{ allowedContent: true, forcePasteAsPlainText:
         false }'

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/training-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/training-pages.yaml
@@ -18,8 +18,8 @@
       jcr:mixinTypes: ['mix:referenceable']
       jcr:uuid: c0662a71-5458-4d26-8ef6-03177733d542
       hee:addToAZ: false
-      hee:caption: I am the caption
-      hee:summary: This is the training programmes homepage
+      hee:programmeDescription: I am the Programme description
+      hee:subtitle: I am the subtitle
       hee:title: Training Homepage
       hippo:availability: []
       hippostd:retainable: false
@@ -154,8 +154,8 @@
       jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
       jcr:uuid: dface5d9-3912-444f-b9a8-b05a11049915
       hee:addToAZ: false
-      hee:caption: I am the caption
-      hee:summary: This is the training programmes homepage
+      hee:programmeDescription: I am the Programme description
+      hee:subtitle: I am the subtitle
       hee:title: Training Homepage
       hippo:availability: [preview]
       hippostd:retainable: false
@@ -282,8 +282,8 @@
       jcr:mixinTypes: ['mix:referenceable']
       jcr:uuid: c7baa9bb-d1c9-48c0-b8f3-6bb303c96ae9
       hee:addToAZ: false
-      hee:caption: I am the caption
-      hee:summary: This is the training programmes homepage
+      hee:programmeDescription: I am the Programme description
+      hee:subtitle: I am the subtitle
       hee:title: Training Homepage
       hippo:availability: [live]
       hippostd:retainable: false

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/training-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/training-pages.yaml
@@ -40,16 +40,16 @@
         hippo:modes: []
         hippo:values: []
       /hee:overview:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>This is the overview section</p>
       /hee:trainingRoutes[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the training routes</p>
       /hee:pathways[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the pathways</p>
       /hee:support[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the support</p>
       /hee:rightHandBlocks[1]:
         jcr:primaryType: hee:QuickLinks
@@ -176,16 +176,16 @@
         hippo:modes: []
         hippo:values: []
       /hee:overview:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>This is the overview section</p>
       /hee:trainingRoutes[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the training routes</p>
       /hee:pathways[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the pathways</p>
       /hee:support[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the support</p>
       /hee:rightHandBlocks[1]:
         jcr:primaryType: hee:QuickLinks
@@ -305,16 +305,16 @@
         hippo:modes: []
         hippo:values: []
       /hee:overview:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>This is the overview section</p>
       /hee:trainingRoutes[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the training routes</p>
       /hee:pathways[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the pathways</p>
       /hee:support[1]:
-        jcr:primaryType: hippostd:html
+        jcr:primaryType: hee:htmlWithoutHeadingOneAndTwo
         hippostd:content: <p>I am the support</p>
       /hee:rightHandBlocks[1]:
         jcr:primaryType: hee:QuickLinks

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/trainingProgrammesHomePage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/trainingProgrammesHomePage-main.ftl
@@ -25,8 +25,8 @@
                             <div class="nhsuk-grid-column-two-thirds">
                                 <div${heroType}>
                                     <h1 class="nhsuk-u-margin-bottom-3">${document.title}</h1>
-                                    <#if document.summary??>
-                                        <p class="nhsuk-body-l nhsuk-u-margin-bottom-0"><@hst.html formattedText="${document.summary!?replace('\n', '<br>')}"/></p>
+                                    <#if document.subtitle?has_content>
+                                        <p class="nhsuk-body-l nhsuk-u-margin-bottom-0">${document.subtitle}</p>
                                     </#if>
                                     <span class="nhsuk-hero__arrow" aria-hidden="true"></span>
                                 </div>
@@ -41,8 +41,8 @@
             <div class="page__layout">
                 <div class="page__main">
                     <section class="nhsuk-section__content">
-                        <#if document.caption??>
-                            <p class="nhsuk-body-l"><@hst.html formattedText="${document.caption!?replace('\n', '<br>')}"/></p>
+                        <#if document.programmeDescription?has_content>
+                            <p class="nhsuk-body-l"><@hst.html formattedText="${document.programmeDescription!?replace('\n', '<br>')}"/></p>
                         </#if>
 
                         <#if document.overview??>

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/RichTextWithoutHeadingOneAndTwo.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/RichTextWithoutHeadingOneAndTwo.java
@@ -1,0 +1,15 @@
+package uk.nhs.hee.web.beans;
+
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+
+@HippoEssentialsGenerated(internalName = "hee:richTextWithoutHeadingOneAndTwo")
+@Node(jcrType = "hee:richTextWithoutHeadingOneAndTwo")
+public class RichTextWithoutHeadingOneAndTwo extends HippoCompound {
+    @HippoEssentialsGenerated(internalName = "hee:content")
+    public HippoHtml getContent() {
+        return getHippoHtml("hee:content");
+    }
+}

--- a/site/components/src/main/java/uk/nhs/hee/web/beans/TrainingProgrammesHomepage.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/beans/TrainingProgrammesHomepage.java
@@ -18,9 +18,9 @@ public class TrainingProgrammesHomepage extends BaseDocument {
         return getSingleProperty("hee:title");
     }
 
-    @HippoEssentialsGenerated(internalName = "hee:summary")
-    public String getSummary() {
-        return getSingleProperty("hee:summary");
+    @HippoEssentialsGenerated(internalName = "hee:subtitle")
+    public String getSubtitle() {
+        return getSingleProperty("hee:subtitle");
     }
 
     @HippoEssentialsGenerated(internalName = "hee:addToAZ")
@@ -63,8 +63,8 @@ public class TrainingProgrammesHomepage extends BaseDocument {
         return getChildBeansByName("hee:rightHandBlocks");
     }
 
-    @HippoEssentialsGenerated(internalName = "hee:caption")
-    public String getCaption() {
-        return getSingleProperty("hee:caption");
+    @HippoEssentialsGenerated(internalName = "hee:programmeDescription")
+    public String getProgrammeDescription() {
+        return getSingleProperty("hee:programmeDescription");
     }
 }


### PR DESCRIPTION
Replaces #482

- Replaces the `Summary` `Text` (area) field with a `Subtitle` `String` (i.e. text box) field with 120 characters limit.
- Replaces the `Caption` `Text` (area) field with a `Programme description` `Text` (area) field.
- Removes `Heading 1` & `Heading 2` styles from `Overview` RichText field.
- Removes `Heading 1` & `Heading 2` styles from `Free text` content block of `Pathways`, `Training Routes` and `Support` fields.