### PR TITLE
[NWPS-1673] Add Tags taxonomy to system

### DIFF
--- a/cms-dependencies/pom.xml
+++ b/cms-dependencies/pom.xml
@@ -89,5 +89,17 @@
       <artifactId>text-search-replace-frontend</artifactId>
       <version>${bloomreach.text-search-replace.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-addon-frontend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-addon-repository</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/essentials/src/main/resources/taxonomyPlugin.xml
+++ b/essentials/src/main/resources/taxonomyPlugin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<installerDocument>
+    <dateAdded>2023-08-08T11:54:11.945+01:00</dateAdded>
+    <dateInstalled>2023-08-08T11:54:11.945+01:00</dateInstalled>
+    <installationState>installed</installationState>
+</installerDocument>

--- a/repository-data/application/src/main/resources/hcm-content/taxonomies.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/taxonomies.yaml
@@ -1,0 +1,683 @@
+/content/taxonomies:
+  jcr:primaryType: hippotaxonomy:container
+  /GlobalTags:
+    jcr:primaryType: hippo:handle
+    jcr:mixinTypes: ['hippo:versionInfo']
+    hippo:versionHistory: 159c5ccf-0c04-40b8-82bf-c75386f8dea6
+    /GlobalTags[1]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:versionable']
+      jcr:uuid: f5320263-6b28-4b47-bfcb-39962d11a829
+      hippo:availability: [live]
+      hippostd:holder: admin
+      hippostd:retainable: false
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-08-08T11:56:51.509+01:00
+      hippostdpubwf:lastModificationDate: 2023-08-08T15:24:07.409+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2023-08-08T15:37:12.480+01:00
+      hippotaxonomy:defaultLocale: en
+      hippotaxonomy:locales: [en]
+      /advocacy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: advocacy
+        locale.en.name: Advocacy
+      /apprenticeship:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: apprenticeship
+        locale.en.name: Apprenticeship
+      /aritificial-intelligence-and-robotics:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: aritificial-intelligence-and-robotics
+        locale.en.name: Aritificial intelligence and robotics
+      /authentication:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: authentication
+        locale.en.name: Authentication
+      /best-practice:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: best-practice
+        locale.en.name: Best practice
+      /blended-learning:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: blended-learning
+        locale.en.name: Blended learning
+      /board-development:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: board-development
+        locale.en.name: Board development
+      /bursaries-grants-and-awards:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: bursaries-grants-and-awards
+        locale.en.name: Bursaries, grants and awards
+      /cataloguing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: cataloguing
+        locale.en.name: Cataloguing
+      /circulation-and-counter-activities:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: circulation-and-counter-activities
+        locale.en.name: Circulation and counter activities
+      /collaboration-and-partnership:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: collaboration-and-partnership
+        locale.en.name: Collaboration and partnership
+      /consultation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: consultation
+        locale.en.name: Consultation
+      /covid-19:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: covid-19
+        locale.en.name: COVID-19
+      /continuing-professional-development:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: continuing-professional-development
+        locale.en.name: Continuing professional development
+      /copyright-and-licensing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: copyright-and-licensing
+        locale.en.name: Copyright and licensing
+      /databases:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: databases
+        locale.en.name: Databases
+      /development-needs:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: development-needs
+        locale.en.name: Development needs
+      /digital-capability-frameworks:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-capability-frameworks
+        locale.en.name: Digital capability frameworks
+      /digital-health-leadership:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-health-leadership
+        locale.en.name: Digital health leadership
+      /digital-literacy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-literacy
+        locale.en.name: Digital literacy
+      /digital-roles-and-career-pathways:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-roles-and-career-pathways
+        locale.en.name: Digital roles and career pathways
+      /discovery:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: discovery
+        locale.en.name: Discovery
+      /electronic-resources:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: electronic-resources
+        locale.en.name: Electronic resources
+      /emerging-technology:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: emerging-technology
+        locale.en.name: Emerging technology
+      /equality-impact-and-diversity:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: equality-impact-and-diversity
+        locale.en.name: Equality, impact and diversity
+      /evaluation-framework:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: evaluation-framework
+        locale.en.name: Evaluation framework
+      /events:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: events
+        locale.en.name: Events
+      /evidence-and-knowledge-self-assessments:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: evidence-and-knowledge-self-assessments
+        locale.en.name: Evidence and knowledge self assessments
+      /fellowships-and-scholarships:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: fellowships-and-scholarships
+        locale.en.name: Fellowships and scholarships
+      /finance:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: finance
+        locale.en.name: Finance
+      /graduates:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: graduates
+        locale.en.name: Graduates
+      /communities-of-practice:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: communities-of-practice
+        locale.en.name: Communities of practice
+      /health-literacy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-literacy
+        locale.en.name: Health literacy
+      /help-and-guidance:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: help-and-guidance
+        locale.en.name: Help and guidance
+      /impact-and-value:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: impact-and-value
+        locale.en.name: Impact and value
+      /industry:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: industry
+        locale.en.name: Industry
+      /innovation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: innovation
+        locale.en.name: Innovation
+      /inter-library-loan-and-document-supply:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: inter-library-loan-and-document-supply
+        locale.en.name: Inter-library loan and document supply
+      /knowledge-for-healthcare:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: knowledge-for-healthcare
+        locale.en.name: Knowledge for Healthcare
+      /learning-and-development:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: learning-and-development
+        locale.en.name: Learning and development
+      /learning-zone:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: learning-zone
+        locale.en.name: Learning zone
+      /libkey-nomad:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: libkey-nomad
+        locale.en.name: LibKey Nomad
+      /library-management-systems:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: library-management-systems
+        locale.en.name: Library management systems
+      /literature-searching:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: literature-searching
+        locale.en.name: Literature searching
+      /managing-talent:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: managing-talent
+        locale.en.name: Managing talent
+      /marketing-and-campaigns:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: marketing-and-campaigns
+        locale.en.name: Marketing and campaigns
+      /mentoring:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: mentoring
+        locale.en.name: Mentoring
+      /mergers:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: mergers
+        locale.en.name: Mergers
+      /mobilising-evidence-and-knowledge:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: mobilising-evidence-and-knowledge
+        locale.en.name: Mobilising evidence and knowledge
+      /networking:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: networking
+        locale.en.name: Networking
+      /nhs-and-healthcare-systems:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nhs-and-healthcare-systems
+        locale.en.name: NHS and healthcare systems
+      /nhs-digital-academy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nhs-digital-academy
+        locale.en.name: NHS Digital Academy
+      /occupational-frameworks:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: occupational-frameworks
+        locale.en.name: Occupational frameworks
+      /open-access:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: open-access
+        locale.en.name: Open access
+      /patient-information:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: patient-information
+        locale.en.name: Patient information
+      /professional-knowledge-and-skills-base-pksb:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: professional-knowledge-and-skills-base-pksb
+        locale.en.name: Professional Knowledge and Skills Base (PKSB)
+      /placements:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: placements
+        locale.en.name: Placements
+      /policy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: policy
+        locale.en.name: Policy
+      /professional-networks:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: professional-networks
+        locale.en.name: Professional networks
+      /quality:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: quality
+        locale.en.name: Quality
+      /quality-and-improvement-outcomes:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: quality-and-improvement-outcomes
+        locale.en.name: Quality and Improvement Outcomes
+      /regional-skills-development-networks:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: regional-skills-development-networks
+        locale.en.name: Regional Skills Development Networks
+      /repositories:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: repositories
+        locale.en.name: Repositories
+      /research:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: research
+        locale.en.name: Research
+      /resource-discovery:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: resource-discovery
+        locale.en.name: Resource Discovery
+      /school-leavers:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: school-leavers
+        locale.en.name: School leavers
+      /service-delivery:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: service-delivery
+        locale.en.name: Service delivery
+      /social-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: social-care
+        locale.en.name: Social care
+      /statistics-and-data:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: statistics-and-data
+        locale.en.name: Statistics and data
+      /strategy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: strategy
+        locale.en.name: Strategy
+      /streamlining:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: streamlining
+        locale.en.name: Streamlining
+      /sustainability:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: sustainability
+        locale.en.name: Sustainability
+      /tools-and-techniques:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: tools-and-techniques
+        locale.en.name: Tools and techniques
+      /training:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: training
+        locale.en.name: Training
+      /use-of-technology:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: use-of-technology
+        locale.en.name: Use of technology
+      /user-experience:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: user-experience
+        locale.en.name: User experience
+      /wellbeing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: wellbeing
+        locale.en.name: Wellbeing
+      /wider-profession:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: wider-profession
+        locale.en.name: Wider profession
+      /workforce:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: workforce
+        locale.en.name: Workforce
+    /GlobalTags[2]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable', 'mix:versionable']
+      jcr:uuid: 1ae97b65-2aa2-4aca-93d5-c56b44cebcae
+      hippo:availability: [preview]
+      hippostd:retainable: false
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-08-08T11:56:51.509+01:00
+      hippostdpubwf:lastModificationDate: 2023-08-08T15:24:07.409+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippotaxonomy:defaultLocale: en
+      hippotaxonomy:locales: [en]
+      /advocacy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: advocacy
+        locale.en.name: Advocacy
+      /apprenticeship:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: apprenticeship
+        locale.en.name: Apprenticeship
+      /aritificial-intelligence-and-robotics:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: aritificial-intelligence-and-robotics
+        locale.en.name: Aritificial intelligence and robotics
+      /authentication:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: authentication
+        locale.en.name: Authentication
+      /best-practice:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: best-practice
+        locale.en.name: Best practice
+      /blended-learning:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: blended-learning
+        locale.en.name: Blended learning
+      /board-development:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: board-development
+        locale.en.name: Board development
+      /bursaries-grants-and-awards:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: bursaries-grants-and-awards
+        locale.en.name: Bursaries, grants and awards
+      /cataloguing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: cataloguing
+        locale.en.name: Cataloguing
+      /circulation-and-counter-activities:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: circulation-and-counter-activities
+        locale.en.name: Circulation and counter activities
+      /collaboration-and-partnership:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: collaboration-and-partnership
+        locale.en.name: Collaboration and partnership
+      /consultation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: consultation
+        locale.en.name: Consultation
+      /covid-19:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: covid-19
+        locale.en.name: COVID-19
+      /continuing-professional-development:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: continuing-professional-development
+        locale.en.name: Continuing professional development
+      /copyright-and-licensing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: copyright-and-licensing
+        locale.en.name: Copyright and licensing
+      /databases:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: databases
+        locale.en.name: Databases
+      /development-needs:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: development-needs
+        locale.en.name: Development needs
+      /digital-capability-frameworks:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-capability-frameworks
+        locale.en.name: Digital capability frameworks
+      /digital-health-leadership:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-health-leadership
+        locale.en.name: Digital health leadership
+      /digital-literacy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-literacy
+        locale.en.name: Digital literacy
+      /digital-roles-and-career-pathways:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: digital-roles-and-career-pathways
+        locale.en.name: Digital roles and career pathways
+      /discovery:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: discovery
+        locale.en.name: Discovery
+      /electronic-resources:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: electronic-resources
+        locale.en.name: Electronic resources
+      /emerging-technology:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: emerging-technology
+        locale.en.name: Emerging technology
+      /equality-impact-and-diversity:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: equality-impact-and-diversity
+        locale.en.name: Equality, impact and diversity
+      /evaluation-framework:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: evaluation-framework
+        locale.en.name: Evaluation framework
+      /events:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: events
+        locale.en.name: Events
+      /evidence-and-knowledge-self-assessments:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: evidence-and-knowledge-self-assessments
+        locale.en.name: Evidence and knowledge self assessments
+      /fellowships-and-scholarships:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: fellowships-and-scholarships
+        locale.en.name: Fellowships and scholarships
+      /finance:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: finance
+        locale.en.name: Finance
+      /graduates:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: graduates
+        locale.en.name: Graduates
+      /communities-of-practice:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: communities-of-practice
+        locale.en.name: Communities of practice
+      /health-literacy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: health-literacy
+        locale.en.name: Health literacy
+      /help-and-guidance:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: help-and-guidance
+        locale.en.name: Help and guidance
+      /impact-and-value:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: impact-and-value
+        locale.en.name: Impact and value
+      /industry:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: industry
+        locale.en.name: Industry
+      /innovation:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: innovation
+        locale.en.name: Innovation
+      /inter-library-loan-and-document-supply:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: inter-library-loan-and-document-supply
+        locale.en.name: Inter-library loan and document supply
+      /knowledge-for-healthcare:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: knowledge-for-healthcare
+        locale.en.name: Knowledge for Healthcare
+      /learning-and-development:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: learning-and-development
+        locale.en.name: Learning and development
+      /learning-zone:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: learning-zone
+        locale.en.name: Learning zone
+      /libkey-nomad:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: libkey-nomad
+        locale.en.name: LibKey Nomad
+      /library-management-systems:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: library-management-systems
+        locale.en.name: Library management systems
+      /literature-searching:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: literature-searching
+        locale.en.name: Literature searching
+      /managing-talent:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: managing-talent
+        locale.en.name: Managing talent
+      /marketing-and-campaigns:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: marketing-and-campaigns
+        locale.en.name: Marketing and campaigns
+      /mentoring:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: mentoring
+        locale.en.name: Mentoring
+      /mergers:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: mergers
+        locale.en.name: Mergers
+      /mobilising-evidence-and-knowledge:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: mobilising-evidence-and-knowledge
+        locale.en.name: Mobilising evidence and knowledge
+      /networking:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: networking
+        locale.en.name: Networking
+      /nhs-and-healthcare-systems:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nhs-and-healthcare-systems
+        locale.en.name: NHS and healthcare systems
+      /nhs-digital-academy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: nhs-digital-academy
+        locale.en.name: NHS Digital Academy
+      /occupational-frameworks:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: occupational-frameworks
+        locale.en.name: Occupational frameworks
+      /open-access:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: open-access
+        locale.en.name: Open access
+      /patient-information:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: patient-information
+        locale.en.name: Patient information
+      /professional-knowledge-and-skills-base-pksb:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: professional-knowledge-and-skills-base-pksb
+        locale.en.name: Professional Knowledge and Skills Base (PKSB)
+      /placements:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: placements
+        locale.en.name: Placements
+      /policy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: policy
+        locale.en.name: Policy
+      /professional-networks:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: professional-networks
+        locale.en.name: Professional networks
+      /quality:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: quality
+        locale.en.name: Quality
+      /quality-and-improvement-outcomes:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: quality-and-improvement-outcomes
+        locale.en.name: Quality and Improvement Outcomes
+      /regional-skills-development-networks:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: regional-skills-development-networks
+        locale.en.name: Regional Skills Development Networks
+      /repositories:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: repositories
+        locale.en.name: Repositories
+      /research:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: research
+        locale.en.name: Research
+      /resource-discovery:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: resource-discovery
+        locale.en.name: Resource Discovery
+      /school-leavers:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: school-leavers
+        locale.en.name: School leavers
+      /service-delivery:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: service-delivery
+        locale.en.name: Service delivery
+      /social-care:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: social-care
+        locale.en.name: Social care
+      /statistics-and-data:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: statistics-and-data
+        locale.en.name: Statistics and data
+      /strategy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: strategy
+        locale.en.name: Strategy
+      /streamlining:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: streamlining
+        locale.en.name: Streamlining
+      /sustainability:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: sustainability
+        locale.en.name: Sustainability
+      /tools-and-techniques:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: tools-and-techniques
+        locale.en.name: Tools and techniques
+      /training:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: training
+        locale.en.name: Training
+      /use-of-technology:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: use-of-technology
+        locale.en.name: Use of technology
+      /user-experience:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: user-experience
+        locale.en.name: User experience
+      /wellbeing:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: wellbeing
+        locale.en.name: Wellbeing
+      /wider-profession:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: wider-profession
+        locale.en.name: Wider profession
+      /workforce:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: workforce
+        locale.en.name: Workforce
+    /GlobalTags[3]:
+      jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable']
+      jcr:uuid: b534d3c3-4faf-41d8-ad72-d3ea621a93c4
+      hippo:availability: []
+      hippostd:retainable: false
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2023-08-08T11:56:51.509+01:00
+      hippostdpubwf:lastModificationDate: 2023-08-08T15:24:07.468+01:00
+      hippostdpubwf:lastModifiedBy: admin
+      hippotaxonomy:defaultLocale: en
+      hippotaxonomy:locales: [en]
+      /advocacy:
+        jcr:primaryType: hippotaxonomy:category
+        hippotaxonomy:key: advocacy
+        locale.en.name: Advocacy

--- a/site/components/pom.xml
+++ b/site/components/pom.xml
@@ -82,6 +82,18 @@
       <artifactId>hippo-addon-urlrewriter-site-dependencies</artifactId>
       <type>pom</type>
     </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-hst-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-plugin-taxonomy-hstclient</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>


### PR DESCRIPTION
This adds the tags taxonomy to the system. 

This PR and NWPS-1678 both add the taxonomy libraries to POMs as well as adding a new taxonomies node to the /content root. Whichever one is merged second *might* show merge conflicts, but the blocks for each of the respective taxonomies being added in these two PRs is easily merged by hand