### PR TITLE
[NWPS-1679] Rename of publication listing to refer to collection

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/types.yaml
@@ -400,7 +400,7 @@ definitions:
       jcr:primaryType: hipposys:resourcebundles
       /en:
         jcr:primaryType: hipposys:resourcebundle
-        jcr:name: '[Page] Publication collections'
+        jcr:name: '[Collection] Publications'
     /hippo:configuration/hippo:translations/hippo:types/hee:headingsTOC:
       jcr:primaryType: hipposys:resourcebundles
       /en:


### PR DESCRIPTION
Name of page type changed to "[Collection] Publications" to reflect new approach to naming of collections