### PR TITLE
[NWPS-1680] Make summary mandatory for certain document types

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/HomePage.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 154a1da4-0f93-4a6c-ab55-db2393990c96
+          jcr:uuid: e69ceb95-8e36-40df-b57a-0fbed4d7114f
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -39,7 +39,7 @@ definitions:
             hipposysedit:path: hee:summary
             hipposysedit:primary: false
             hipposysedit:type: Text
-            hipposysedit:validators: [optional]
+            hipposysedit:validators: [required]
           /heroImage:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -69,7 +69,7 @@ definitions:
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes: ['mix:referenceable']
-          jcr:uuid: 43389906-5398-4fee-b538-bcd47907bbc5
+          jcr:uuid: 01301efe-19c0-4762-a848-f06809b95ed5
           hippostdpubwf:lastModificationDate: 2021-03-24T17:00:07.151+07:00
           hippostdpubwf:creationDate: 2021-03-24T17:00:07.151+07:00
           hee:title: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/guidanceDocument.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: bc200099-8ae9-4c22-80fa-9a92f8114a20
+          jcr:uuid: b101e8b7-c48f-45fb-81e6-aa863b83d1a0
           hipposysedit:node: true
           hipposysedit:supertype: ['hippostd:taggable', 'hippotranslation:translated',
             'hee:basedocument', 'hippostd:relaxed']
@@ -33,7 +33,7 @@ definitions:
             hipposysedit:path: hee:summary
             hipposysedit:primary: false
             hipposysedit:type: Text
-            hipposysedit:validators: [optional]
+            hipposysedit:validators: [required]
           /contentBlocks:
             jcr:primaryType: hipposysedit:field
             hipposysedit:multiple: true
@@ -103,7 +103,7 @@ definitions:
           jcr:mixinTypes: ['mix:referenceable', 'hippostd:taggable']
           hee:title: ''
           hee:summary: ''
-          jcr:uuid: f926f4a1-7d39-443e-92be-973020f33532
+          jcr:uuid: a23f28ca-8698-4d1c-b4c4-27a147894905
           hippostdpubwf:lastModificationDate: 2021-01-27T11:49:03.685Z
           hippostdpubwf:creationDate: 2021-01-27T11:49:03.686Z
           hee:addToAZ: false

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/landingPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/landingPage.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 6010d40a-0021-4e4b-85a4-645c2cc08d37
+          jcr:uuid: b9dbecf6-320e-4478-8afd-6f21bfc53cf4
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -32,7 +32,7 @@ definitions:
             hipposysedit:path: hee:summary
             hipposysedit:primary: false
             hipposysedit:type: Text
-            hipposysedit:validators: [optional]
+            hipposysedit:validators: [required]
           /heroImage:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -79,7 +79,7 @@ definitions:
           jcr:mixinTypes: ['mix:referenceable']
           hee:title: ''
           hee:summary: ''
-          jcr:uuid: c985ca5d-ec01-48e2-8b5a-7575057b8ac6
+          jcr:uuid: d91207df-738f-48d5-8487-5693714f9282
           hippostdpubwf:lastModificationDate: 2021-02-05T11:01:21.184+07:00
           hippostdpubwf:creationDate: 2021-02-05T11:01:21.185+07:00
           hee:addToAZ: false

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/news.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: c58d130b-75db-4322-aba9-53ad23452ff4
+          jcr:uuid: ae2fe29f-3c67-4850-94ec-a30b0c5e3844
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -32,7 +32,7 @@ definitions:
             hipposysedit:path: hee:summary
             hipposysedit:primary: false
             hipposysedit:type: Text
-            hipposysedit:validators: [optional]
+            hipposysedit:validators: [required]
           /contentBlocks:
             jcr:primaryType: hipposysedit:field
             hipposysedit:multiple: true
@@ -134,7 +134,7 @@ definitions:
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes: ['mix:referenceable']
           hee:title: ''
-          jcr:uuid: a22d5d21-48b5-4b4c-836d-576f1b585c08
+          jcr:uuid: fa592eca-1e3f-4306-a10c-166774bb4391
           hippostdpubwf:lastModificationDate: 2021-01-27T11:49:03.685Z
           hippostdpubwf:creationDate: 2021-01-27T11:49:03.686Z
           hee:summary: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/publicationListingPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/publicationListingPage.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: af966f2a-6ed0-4ac7-a1ee-03abb98b2cbb
+          jcr:uuid: 3e2f4643-a4db-42f8-be83-8fe6eb031e59
           hipposysedit:node: true
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
@@ -32,7 +32,7 @@ definitions:
             hipposysedit:path: hee:summary
             hipposysedit:primary: false
             hipposysedit:type: Text
-            hipposysedit:validators: [optional]
+            hipposysedit:validators: [required]
           /microHero:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -90,7 +90,7 @@ definitions:
           hee:pageSize: 10
           hee:addToAZ: false
           hee:subtitle: ''
-          jcr:uuid: 2e117db9-3a99-462a-b022-8ab61ed35bcd
+          jcr:uuid: ad142100-5227-47b4-b5b1-7074ce2712d3
           hippostdpubwf:lastModificationDate: 2022-12-02T14:26:11.069Z
           hippostdpubwf:creationDate: 2022-12-02T14:26:11.069Z
           /hee:microHero:


### PR DESCRIPTION
Use the query:

//element(*, nt:base)[@jcr:primaryType = 'hee:publicationListingPage' or @jcr:primaryType = 'hee:guidance' or @jcr:primaryType = 'hee:news' or @jcr:primaryType = 'hee:HomePage' or @jcr:primaryType = 'hee:landingPage'][hippostd:state = 'published' and @hee:summary='']/(@jcr:primaryType, @hee:title) order by @jcr:primaryType, @jcr:path descending

to locate elements that have an empty or unspecified summary field for these specific content types