### PR TITLE
[NWPS-1613] Removing the double space between `PDF,` and `large` in the `Other formats` section

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
@@ -128,8 +128,8 @@
                     <#if document.otherFormatsEmail?has_content>
                         <h2>Other formats</h2>
                         <div class="hee-publication-doc">
-                            <p>If you need documents in a different format like accessible PDF,&nbsp;
-                            large print, easy read, audio recording or braille please email
+                            <p>If you need documents in a different format like accessible PDF,
+                                large print, easy read, audio recording or braille please email
                             <a href="mailto:${document.otherFormatsEmail}">${document.otherFormatsEmail}</a>.</p>
                         </div>
                     </#if>


### PR DESCRIPTION
Supersedes #513 - Created the PR by cherry-picking 1b81d65c2f8833e230e197d146687e257860f588 commit, thanks