### PR TITLE
NWPS-1699-Publication-Alternative-versions

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/report-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/report-main.ftl
@@ -14,10 +14,10 @@
     </@hst.link>
 
     <div class="hee-card--details__item">
-        <a class="hee-resources__link" href="${fileURL}" title="${assetLink.assetData.asset.filename}">
+        <a class="hee-resources__link" href="${fileURL}" title="${assetLink.title}">
             <div class="hee-resources__wrapper">
                 <#--  File name  -->
-                <span class="hee-resources__text">${assetLink.assetData.asset.filename?keep_before_last(".")}</span>
+                <span class="hee-resources__text">${assetLink.title}</span>
 
                 <#--  File size: START  -->
                 <#if (assetLink.assetData.asset.lengthMB > 1)>


### PR DESCRIPTION
In publication page, 'Alternative version' section, it needs to show the titles provided by the user, not the file name.