### PR TITLE
[NWPS-1575] Fixing Guidance (SCP) freemarker template

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/guidance-content.ftl
@@ -1,6 +1,5 @@
 <#include "../../include/imports.ftl">
 <#import "../macros/components.ftl" as hee>
-<
 <#-- @ftlvariable name="guidanceDocument" type="uk.nhs.hee.web.beans.Guidance" -->
 
 <@hst.setBundle basename="uk.nhs.hee.web.global,uk.nhs.hee.web.contact"/>
@@ -27,7 +26,7 @@
                 <#--  Main sections: START  -->
                 <div class="page__main">
                     <div class="page__content">
-                        <@guidanceDetail guidanceDocument=guidanceDocument/>
+                        <@hee.guidanceDetail guidanceDocument=guidanceDocument/>
 
                         <#--  Cookie button [for cookies page]  -->
                         <#if showCookiesButton>


### PR DESCRIPTION
Just observed the following error when accessing an SCP page and so made this PR to quickly fix it:
```
[WARNING] [talledLocalContainer] %d{HH:mm:ss} WARN  [HstFreemarkerServlet] The following has evaluated to null or missing:
[INFO] [talledLocalContainer] ==> guidanceDetail  [in template "webfile:/freemarker/hee/macros/guidance-content.ftl" at line 30, column 27]
[INFO] [talledLocalContainer]
[INFO] [talledLocalContainer] ----
[INFO] [talledLocalContainer] Tip: If the failing expression is known to legally refer to something that's sometimes null or missing, either specify a default value like myOptionalVar!myDefault, or use <#if myOptionalVar??>when-present<#else>when-missing</#if>. (These only cover the last step of the expression; to cover the whole expression, use parenthesis: (myOptionalVar.foo)!myDefault, (myOptionalVar.foo)??
[INFO] [talledLocalContainer] ----
[INFO] [talledLocalContainer]
[INFO] [talledLocalContainer] ----
[INFO] [talledLocalContainer] FTL stack trace ("~" means nesting-related):
[INFO] [talledLocalContainer] 	- Failed at: @guidanceDetail guidanceDocument=guid...  [in template "webfile:/freemarker/hee/macros/guidance-content.ftl" in macro "guidance" at line 30, column 25]
[INFO] [talledLocalContainer] 	- Reached through: @guidance guidanceDocument=document  [in template "webfile:/freemarker/hee/catalog/guidance-main.ftl" at line 9, column 3]
[INFO] [talledLocalContainer] ----. To see the stack trace, set 'org.hippoecm.hst.servlet.HstFreemarkerServlet' log-level to debug in log4j configuration or runtime via the logging servlet
```