### PR TITLE
NWPS-1665-FE-Title-tag-Tags-for-google-map-for-accessibility

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/google-map.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/google-map.ftl
@@ -1,7 +1,7 @@
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
 
 <#macro googleMap block>
-    <div class="hee-google-map">
+    <div class="hee-google-map" aria-label="Google Map">
         <#--  Google map embed code  -->
         <#assign embedCode = block.googleMapContentBlock.embedCode>
         <#assign startDoubleQuote= embedCode?index_of('src="')>


### PR DESCRIPTION
AddUpdate the Freemarker template for the component, to include the new aria-label attribute.