### PR TITLE
[NWPS-1692] Supporting additional content blocks for the overview section of training programme page

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/hee/trainingProgrammePage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/hee/trainingProgrammePage.yaml
@@ -16,7 +16,7 @@ definitions:
           hipposysedit:supertype: ['hee:basedocument', 'hippostd:relaxed', 'hippotranslation:translated']
           hipposysedit:uri: http://www.heecmsplatform.com/hee/nt/1.0
           hipposysedit:validators: ['hee:mandatory-professions-or-topics-validator',
-                                    'hee:mandatory-training-journey-validator', 'hee:unique-guidance-page-validator']
+            'hee:mandatory-training-journey-validator', 'hee:unique-guidance-page-validator']
           /title:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
@@ -330,7 +330,7 @@ definitions:
           /overview:
             jcr:primaryType: frontend:plugin
             caption: Overview
-            compoundList: hee:appliesToBoxReference,hippostd:html,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:richTextReference,hee:statementCardReference,hee:warningCalloutReference
+            compoundList: hee:appliesToBoxReference,hee:statementCardReference,hee:detailsReference,hee:expanderGroupReference,hippostd:html,hee:googleMapReference,hippogallerypicker:imagelink,hee:insetReference,hee:mediaEmbedReference,hee:tableReference,hee:expanderTableReference,hee:tabsReference,hee:richTextReference,hee:warningCalloutReference
             contentPickerType: links
             field: overview
             plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/lks/training-programmes-pages.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/lks/training-programmes-pages.yaml
@@ -59,7 +59,7 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
-      /hee:overview:
+      /hee:overview[1]:
         jcr:primaryType: hee:appliesToBoxReference
         /hee:appliesToContentBlock:
           jcr:primaryType: hippo:mirror
@@ -92,6 +92,36 @@
       /hee:featuredContentBlock:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 91a74faa-0fb9-4a0c-ac70-ed3becedd670
+      /hee:overview[2]:
+        jcr:primaryType: hee:detailsReference
+        /hee:detailsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
+      /hee:overview[3]:
+        jcr:primaryType: hee:expanderGroupReference
+        /hee:expanderContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: c6a5f1d2-0b3e-4f0f-bc1a-375146b710fd
+      /hee:overview[4]:
+        jcr:primaryType: hee:googleMapReference
+        /hee:googleMapContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 9f09cb7d-5099-4dba-8683-fc453dfdcb16
+      /hee:overview[5]:
+        jcr:primaryType: hee:tableReference
+        /hee:tabledataContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 94afb585-a7a3-4eb9-a2fd-0836aec4d05a
+      /hee:overview[6]:
+        jcr:primaryType: hee:expanderTableReference
+        /hee:expanderTableContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 4c72c1f9-22a7-4819-be39-f1cf1c54e21a
+      /hee:overview[7]:
+        jcr:primaryType: hee:tabsReference
+        /hee:tabsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 9dfce526-0f2e-4b45-a6cd-c0ce59d229bf
     /training-programmes-page[2]:
       jcr:primaryType: hee:trainingProgrammePage
       jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
@@ -139,7 +169,7 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
-      /hee:overview:
+      /hee:overview[1]:
         jcr:primaryType: hee:appliesToBoxReference
         /hee:appliesToContentBlock:
           jcr:primaryType: hippo:mirror
@@ -172,6 +202,36 @@
       /hee:featuredContentBlock:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 91a74faa-0fb9-4a0c-ac70-ed3becedd670
+      /hee:overview[2]:
+        jcr:primaryType: hee:detailsReference
+        /hee:detailsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
+      /hee:overview[3]:
+        jcr:primaryType: hee:expanderGroupReference
+        /hee:expanderContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: c6a5f1d2-0b3e-4f0f-bc1a-375146b710fd
+      /hee:overview[4]:
+        jcr:primaryType: hee:googleMapReference
+        /hee:googleMapContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 9f09cb7d-5099-4dba-8683-fc453dfdcb16
+      /hee:overview[5]:
+        jcr:primaryType: hee:tableReference
+        /hee:tabledataContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 94afb585-a7a3-4eb9-a2fd-0836aec4d05a
+      /hee:overview[6]:
+        jcr:primaryType: hee:expanderTableReference
+        /hee:expanderTableContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 4c72c1f9-22a7-4819-be39-f1cf1c54e21a
+      /hee:overview[7]:
+        jcr:primaryType: hee:tabsReference
+        /hee:tabsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 9dfce526-0f2e-4b45-a6cd-c0ce59d229bf
     /training-programmes-page[3]:
       jcr:primaryType: hee:trainingProgrammePage
       jcr:mixinTypes: ['mix:referenceable']
@@ -220,7 +280,7 @@
         hippo:facets: []
         hippo:modes: []
         hippo:values: []
-      /hee:overview:
+      /hee:overview[1]:
         jcr:primaryType: hee:appliesToBoxReference
         /hee:appliesToContentBlock:
           jcr:primaryType: hippo:mirror
@@ -253,3 +313,33 @@
       /hee:featuredContentBlock:
         jcr:primaryType: hippo:mirror
         hippo:docbase: 91a74faa-0fb9-4a0c-ac70-ed3becedd670
+      /hee:overview[2]:
+        jcr:primaryType: hee:detailsReference
+        /hee:detailsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: fdf33d93-cb1f-4a12-a954-c5f187e767d2
+      /hee:overview[3]:
+        jcr:primaryType: hee:expanderGroupReference
+        /hee:expanderContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: c6a5f1d2-0b3e-4f0f-bc1a-375146b710fd
+      /hee:overview[4]:
+        jcr:primaryType: hee:googleMapReference
+        /hee:googleMapContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 9f09cb7d-5099-4dba-8683-fc453dfdcb16
+      /hee:overview[5]:
+        jcr:primaryType: hee:tableReference
+        /hee:tabledataContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 94afb585-a7a3-4eb9-a2fd-0836aec4d05a
+      /hee:overview[6]:
+        jcr:primaryType: hee:expanderTableReference
+        /hee:expanderTableContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 4c72c1f9-22a7-4819-be39-f1cf1c54e21a
+      /hee:overview[7]:
+        jcr:primaryType: hee:tabsReference
+        /hee:tabsContentBlock:
+          jcr:primaryType: hippo:mirror
+          hippo:docbase: 9dfce526-0f2e-4b45-a6cd-c0ce59d229bf

--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/trainingProgrammePage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/trainingProgrammePage-main.ftl
@@ -147,7 +147,7 @@
                     <#else>
                         <#--  Main content blocks: START  -->
                         <#if document.overviewBlocks??>
-                            <h2  class="toc_h2" id="overview">Overview</h2>
+                            <h2 class="toc_h2" id="overview">Overview</h2>
                             <#list document.overviewBlocks as block>
                                 <#switch block.getClass().getName()>
                                     <#case "org.hippoecm.hst.content.beans.standard.HippoFacetSelect">
@@ -175,6 +175,24 @@
                                         <#break>
                                     <#case "uk.nhs.hee.web.beans.StatementCardReference">
                                         <@hee.statementCard block=block/>
+                                        <#break>
+                                    <#case "uk.nhs.hee.web.beans.DetailsReference">
+                                        <@hee.details block=block/>
+                                        <#break>
+                                    <#case "uk.nhs.hee.web.beans.ExpanderGroupReference">
+                                        <@hee.expander expander=block/>
+                                        <#break>
+                                    <#case "uk.nhs.hee.web.beans.GoogleMapReference">
+                                        <@hee.googleMap block=block/>
+                                        <#break>
+                                    <#case "uk.nhs.hee.web.beans.TabsReference">
+                                        <@hee.tabs tabs=block/>
+                                        <#break>
+                                    <#case "uk.nhs.hee.web.beans.TableReference">
+                                        <@hee.table table=block/>
+                                        <#break>
+                                    <#case "uk.nhs.hee.web.beans.ExpanderTableReference">
+                                        <@hee.expanderTable table=block/>
                                         <#break>
                                     <#default>
                                 </#switch>


### PR DESCRIPTION
Adds support for `details`, `expander`, `google map`, `table`, `table expander` and `tabs` content blocks on the Training programme page overview section.