### PR TITLE
[NWPS-841] Fix to remove additional bottom space on the main section of the landing page

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/landingPage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/landingPage-main.ftl
@@ -25,10 +25,10 @@
         <#--  Main header: END  -->
 
         <#--  Main content: START  -->
-        <div class="page__main nhsuk-width-container">
-            <div class="page__content">
-                <#--  Main content blocks: START  -->
-                <#if document.contentBlocks??>
+        <#if document.contentBlocks?? && document.contentBlocks?has_content>
+            <div class="page__main nhsuk-width-container">
+                <div class="page__content">
+                    <#--  Main content blocks: START  -->
                     <#list document.contentBlocks as block>
                         <#switch block.getClass().getName()>
                             <#case "uk.nhs.hee.web.beans.ContentCards">
@@ -46,10 +46,10 @@
                             <#default>
                         </#switch>
                     </#list>
-                </#if>
-                <#--  Main content blocks: END  -->
+                    <#--  Main content blocks: END  -->
+                </div>
             </div>
-        </div>
+        </#if>
         <#--  Main content: END  -->
     </main>
 </#if>


### PR DESCRIPTION
The fix is essentially to remove the additional bottom space for `pagenotfound` page (which is now been configured to use the landing page document for rendering) when it doesn't contain any main content blocks.

![Screenshot 2023-10-20 at 09 23 10](https://github.com/Health-Education-England/hee-cms-platform/assets/35143542/20bfaf7f-0afb-46ef-abc8-040e4ab3d713)
