### PR TITLE
[NWPS-1771] Content bootstrapping error fixes

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/website-testing/redirecttospecialtylandingpage.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/urlrewriter/website-testing/redirecttospecialtylandingpage.yaml
@@ -25,14 +25,6 @@
       \n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
       \n    <from>^/website-testing/dental-specialty-training/oral-medicine-mini-hub/?$</from>\r\
       \n    <to type=\"redirect\" last=\"true\">/site/website-testing/dental-specialty-training/oral-medicine-landing/oral-medicine-mini-hub</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n<name>Redirect to speciality landing page for 'website-testing.hee.nhs.uk'\
-      \ host</name>\r\n<condition name=\"host\" operator=\"equal\">website-testing.hee.nhs.uk</condition>\r\
-      \n<from>^/dental-specialty-training/oral-medicine-mini-hub/?$</from>\r\n<to\
-      \ type=\"redirect\" last=\"true\">/dental-specialty-training/oral-medicine-landing/oral-medicine-mini-hub</to>\r\
-      \n</rule>\r\n\r\n<rule>\r\n    <name>Search Redirect for hosts other than 'hee.nhs.uk'</name>\r\
-      \n    <condition name=\"host\" operator=\"notequal\">hee.nhs.uk</condition>\r\
-      \n    <from>^/website-testing/dental-specialty-training/oral-medicine-mini-hub/?$</from>\r\
-      \n    <to type=\"redirect\" last=\"true\">/site/website-testing/dental-specialty-training/oral-medicine-landing/oral-medicine-mini-hub</to>\r\
       \n</rule>"
   /redirecttospecialtylandingpage[2]:
     jcr:primaryType: urlrewriter:xmlrule


### PR DESCRIPTION
- Keeping the `draft` version of `/content/urlrewriter/website-testing/redirecttospecialtylandingpage` in sync.