### PR TITLE
[NWPS-1787] NextReviewDateNotification repository job build

### DIFF
--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -113,4 +113,4 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-platform.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -109,7 +109,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-platform.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'
 
   deploy-to-test:
     name: Deploy to Test Env. [on brCloud]
@@ -178,7 +178,7 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-platform.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'
 
   deploy-to-staging:
     name: Deploy to Staging Env. [on brCloud]
@@ -249,4 +249,4 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-platform.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'

--- a/cms-dependencies/pom.xml
+++ b/cms-dependencies/pom.xml
@@ -61,6 +61,11 @@
       <groupId>com.onehippo.cms7</groupId>
       <artifactId>hippo-addon-eforms-cms</artifactId>
     </dependency>
+    <!-- Added here to leverage the classes under 'com.onehippo.cms7.eforms.hst.util.mail' package -->
+    <dependency>
+      <groupId>com.onehippo.cms7</groupId>
+      <artifactId>hippo-addon-eforms-hst</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.onehippo.cms7</groupId>
       <artifactId>hippo-addon-urlrewriter-cms-dependencies</artifactId>

--- a/cms/src/main/java/uk/nhs/hee/web/repository/scheduling/NextReviewDateNotification.java
+++ b/cms/src/main/java/uk/nhs/hee/web/repository/scheduling/NextReviewDateNotification.java
@@ -1,21 +1,17 @@
 package uk.nhs.hee.web.repository.scheduling;
 
-import com.sun.mail.smtp.SMTPMessage;
+import com.onehippo.cms7.eforms.hst.util.mail.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jackrabbit.JcrConstants;
-import org.hippoecm.hst.configuration.hosting.Mount;
-import org.hippoecm.hst.configuration.hosting.VirtualHosts;
-import org.hippoecm.hst.platform.model.HstModel;
-import org.hippoecm.hst.platform.model.HstModelRegistry;
 import org.hippoecm.repository.util.DateTools;
 import org.hippoecm.repository.util.JcrUtils;
-import org.jsoup.Jsoup;
-import org.onehippo.cms7.services.HippoServiceRegistry;
 import org.onehippo.repository.scheduling.RepositoryJob;
 import org.onehippo.repository.scheduling.RepositoryJobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.nhs.hee.web.utils.DocumentUtils;
+import uk.nhs.hee.web.utils.MailUtils;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -23,20 +19,17 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
-import javax.mail.*;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMultipart;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
+import javax.mail.MessagingException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * The repository job class which sends email notification with documents to be reviewed in the next 14 days.
+ */
 public class NextReviewDateNotification implements RepositoryJob {
     // Logger
     private static final Logger LOGGER = LoggerFactory.getLogger(NextReviewDateNotification.class);
@@ -69,25 +62,9 @@ public class NextReviewDateNotification implements RepositoryJob {
                     "/*[(%s) and @hippostd:state='published']/element(hee:pageLastNextReview, hee:pageLastNextReview)" +
                     "[@%s and @%s = %s]/../..";
 
-    // CMS context path
-    public static final String CMS_CONTEXT_PATH = "/cms";
-
-    // Host groups
-    public static final String HOST_GROUP_BR_CLOUD = "br-cloud";
-    public static final String HOST_GROUP_DEV_LOCAL_HOST = "dev-localhost";
-
-    // 'brc.environmentname' system property
-    public static final String SYSTEM_PROPERTY_BRC_ENV_NAME = "brc.environmentname";
-
     // Email content/body text placeholders
     public static final String EMAIL_CONTENT_PLACEHOLDER_NEXT_REVIEW_DATE = "{{next_review_date}}";
     public static final String EMAIL_CONTENT_PLACEHOLDER_DOCUMENTS_WITH_LINKS = "{{documents_with_links}}";
-
-    // Mail session bind/lookup name
-    public static final String MAIL_SESSION_NAME = "mail/Session";
-
-    // Regular expression to split comma separated values
-    public static final String SPLIT_COMMA_SEPARATED_VALUES_REGEX = "\\s*,\\s*";
 
     @Override
     public void execute(final RepositoryJobExecutionContext context) throws RepositoryException {
@@ -106,7 +83,7 @@ public class NextReviewDateNotification implements RepositoryJob {
 
                 if (!documentsToBeReviewed.isEmpty()) {
                     // Notify content or channel team
-                    notify(context, session, documentsToBeReviewed);
+                    notify(context, documentsToBeReviewed);
                 } else {
                     LOGGER.info("There are no documents to be reviewed in the next 14 days!");
                 }
@@ -123,6 +100,14 @@ public class NextReviewDateNotification implements RepositoryJob {
         }
     }
 
+    /**
+     * Returns the list of published documents (of {@code documentTypes}) which requires reviewing in the next 14 days.
+     *
+     * @param session       the {@link Session} instance.
+     * @param documentTypes the comma separated list of document types whose documents require reviewing.
+     * @return the list of published documents (of {@code documentTypes}) which requires reviewing in the next 14 days.
+     * @throws RepositoryException thrown when an error occurs during document search.
+     */
     private List<Node> getDocumentsToBeReviewed(final Session session, final String documentTypes)
             throws RepositoryException {
         final QueryManager queryManager = session.getWorkspace().getQueryManager();
@@ -146,7 +131,7 @@ public class NextReviewDateNotification implements RepositoryJob {
     }
 
     private String getFormattedPrimaryDocumentTypes(final String documentTypes) {
-        return Arrays.stream(documentTypes.split(SPLIT_COMMA_SEPARATED_VALUES_REGEX))
+        return uk.nhs.hee.web.utils.StringUtils.transformCommaSeparatedStringIntoStringList(documentTypes)
                 .map(documentType -> String.format("@" + JcrConstants.JCR_PRIMARYTYPE + "='%s'", documentType.trim()))
                 .collect(Collectors.joining(" or "));
     }
@@ -157,9 +142,15 @@ public class NextReviewDateNotification implements RepositoryJob {
         return fourteenDaysFromToday;
     }
 
+    /**
+     * Sends an email notification about the given list of documents to be reviewed {@code documentsToBeReviewed}
+     * based on the configured email specific attributes.
+     *
+     * @param context               the {@link RepositoryJobExecutionContext} instance.
+     * @param documentsToBeReviewed the list of documents to be reviewed.
+     */
     private void notify(
             final RepositoryJobExecutionContext context,
-            final Session session,
             final List<Node> documentsToBeReviewed) {
         try {
             if (!areRequiredEmailAttributesAvailable(context)) {
@@ -176,66 +167,48 @@ public class NextReviewDateNotification implements RepositoryJob {
                     StringUtils.trim(context.getAttribute(ATTRIBUTE_EMAIL_BODY_PLAIN_TEXT_TEMPLATE));
 
             // Create message
-            final javax.mail.Session mailSession = getMailSession();
+            final javax.mail.Session mailSession = MailUtils.getMailSession();
             if (mailSession == null) {
-                LOGGER.warn("Email session '{}' isn't available. Halting the job for now!", MAIL_SESSION_NAME);
+                LOGGER.warn("Email session isn't available. Halting the job for now!");
                 return;
             }
-            final SMTPMessage msg = new SMTPMessage(mailSession);
 
-            // Set from address
-            msg.setFrom(createAddress(fromName, fromEmail));
+            final MailAddress fromMailAddress = new MailAddressImpl(fromName, fromEmail);
+            final MailSender mailSender = new MailSenderImpl(mailSession, fromMailAddress, fromMailAddress);
 
-            // Set sender
-            msg.setSender(createAddress(fromName, fromEmail));
-
-            // Set reply to if needed
-            // msg.setReplyTo();
-
-            // Set envelope from
-            msg.setEnvelopeFrom(fromEmail);
-
-            // Set to/recipient
-            final Address[] addresses = getAddresses(toEmails);
-            msg.addRecipients(Message.RecipientType.TO, addresses);
-
-            // Set subject
-            msg.setSubject(subject);
-
-            // Set content
-            final MimeMultipart mimeAlternativePart = new MimeMultipart("alternative");
             final Pair<String, String> formattedEmailBody =
                     formatEmailBody(bodyHTMLTemplate, bodyPlainTextTemplate, documentsToBeReviewed);
-            LOGGER.debug("Formatted email body HTML: {}", formattedEmailBody.getLeft());
-            LOGGER.debug("Formatted email body plain text: {}", formattedEmailBody.getRight());
 
-            // HTML body
-            final BodyPart htmlBodyPart = new MimeBodyPart();
-            htmlBodyPart.setContent(
+            final MailTemplate mail = new MailTemplate(
+                    mailSender,
+                    MailUtils.getAddresses(toEmails),
+                    subject,
                     formattedEmailBody.getLeft(),
-                    "text/html; charset=" + StandardCharsets.UTF_8.name());
-            mimeAlternativePart.addBodyPart(htmlBodyPart);
+                    formattedEmailBody.getRight());
 
-            // Plain text body
-            final BodyPart textBodyPart = new MimeBodyPart();
-            textBodyPart.setContent(
-                    formattedEmailBody.getRight(),
-                    "text/plain; charset=" + StandardCharsets.UTF_8.name());
-            mimeAlternativePart.addBodyPart(textBodyPart);
-            msg.setContent(mimeAlternativePart);
-
-            // Finally, send
-            Transport.send(msg);
-        } catch(final MessagingException e) {
+            mail.sendMessage();
+        } catch (final MessagingException e) {
             LOGGER.error("Caught error '{}' while preparing and sending the email message", e.getMessage(), e);
         }
     }
 
+    /**
+     * Returns the formatted email body HTML and plain text as a {@link Pair}
+     * by substituting the placeholders (e.g. {{next_review_date}}, {{documents_with_links}}, etc.)
+     * with appropriate values.
+     *
+     * @param emailBodyHTML         the email body HTML which needs to be formatted.
+     * @param emailBodyPlainText    the email body plain text which needs to be formatted.
+     * @param documentsToBeReviewed the {@link List} of documents which needs to be reviewed.
+     * @return the formatted email body HTML and plain text as a {@link Pair}
+     * by substituting the placeholders (e.g. {{next_review_date}}, {{documents_with_links}}, etc.)
+     * with appropriate values.
+     */
     private Pair<String, String> formatEmailBody(
             final String emailBodyHTML,
             final String emailBodyPlainText,
             final List<Node> documentsToBeReviewed) {
-        // Format/update '<next_review_date>' placeholder with 14 days from day in 'd MMMM yyyy' format
+        // Format/update '{{next_review_date}}' placeholder with 14 days from day in 'd MMMM yyyy' format
         final String formatted14DaysFromToday =
                 new SimpleDateFormat("d MMMM yyyy").format(get14DaysFromToday().getTime());
         String formattedEmailBodyHTML = emailBodyHTML.replace(
@@ -246,7 +219,7 @@ public class NextReviewDateNotification implements RepositoryJob {
         // Build documents-to-be-reviewed as a list of links
         final StringBuilder documentsWithLinksForHTMLBody = new StringBuilder("<ul>");
         final StringBuilder documentsWithLinksForPlainTextBody = new StringBuilder();
-        final String cmsBaseContentURL = getCMSBaseContentURL();
+        final String cmsBaseContentURL = DocumentUtils.getDocumentBaseURL();
         for (final Node documentToBeReviewed: documentsToBeReviewed) {
             try {
                 documentsWithLinksForHTMLBody
@@ -272,10 +245,10 @@ public class NextReviewDateNotification implements RepositoryJob {
         // Remove the trailing new line (\n) from the built documents-to-be-reviewed
         if (documentsWithLinksForPlainTextBody.length() >  0 &&
                 documentsWithLinksForPlainTextBody.charAt(documentsWithLinksForPlainTextBody.length() -  1) == '\n') {
-            documentsWithLinksForPlainTextBody.setLength(documentsWithLinksForPlainTextBody.length() -  1);
+            documentsWithLinksForPlainTextBody.setLength(documentsWithLinksForPlainTextBody.length() - 1);
         }
 
-        // Finally, format/update '<documents_with_links>' placeholder with a list of document links to be reviewed.
+        // Finally, format/update '{{documents_with_links}}' placeholder with a list of document links to be reviewed.
         formattedEmailBodyHTML = formattedEmailBodyHTML.replace(
                 EMAIL_CONTENT_PLACEHOLDER_DOCUMENTS_WITH_LINKS, documentsWithLinksForHTMLBody.toString());
         formattedEmailBodyPlainText = formattedEmailBodyPlainText.replace(
@@ -284,13 +257,17 @@ public class NextReviewDateNotification implements RepositoryJob {
         return Pair.of(formattedEmailBodyHTML, formattedEmailBodyPlainText);
     }
 
-    private String convertToEmailPlainBodyText(final String emailBodyHTML) {
-        return Jsoup.parse(emailBodyHTML).wholeText();
-    }
-
+    /**
+     * Returns {@code true} if all the email attributes listed in {@code REQUIRED_EMAIL_ATTRIBUTES} have values.
+     * Otherwise, returns {@code false}.
+     *
+     * @param context the {@link RepositoryJobExecutionContext} instance.
+     * @return {@code true} if all the email attributes listed in {@code REQUIRED_EMAIL_ATTRIBUTES} have values.
+     * Otherwise, returns {@code false}.
+     */
     private boolean areRequiredEmailAttributesAvailable(final RepositoryJobExecutionContext context) {
         final List<String> blankEmailAttributes = new ArrayList<>();
-        for (final String attributeName: REQUIRED_EMAIL_ATTRIBUTES) {
+        for (final String attributeName : REQUIRED_EMAIL_ATTRIBUTES) {
             final String emailAttributeValue = context.getAttribute(attributeName);
             logConfiguredAttributeDebugMsg(attributeName, emailAttributeValue);
 
@@ -310,99 +287,13 @@ public class NextReviewDateNotification implements RepositoryJob {
         return true;
     }
 
-    private Address[] getAddresses(final String toEmails) {
-        return Arrays.stream(toEmails.split(SPLIT_COMMA_SEPARATED_VALUES_REGEX))
-                .map(address -> createAddress(null, address))
-                .toArray(Address[]::new);
-    }
-
-    public static Address createAddress(final String name, final String email) {
-        try {
-            if (StringUtils.isEmpty(name)) {
-                return new InternetAddress(email);
-            }
-
-            return new InternetAddress(email, name);
-        } catch (final UnsupportedEncodingException | AddressException e) {
-            LOGGER.error("Caught error '{}' while creating email address with name='{}' and email='{}'",
-                    e.getMessage(), name, email, e);
-        }
-
-        return null;
-    }
-
-    private javax.mail.Session getMailSession() {
-        Context initialContext = null;
-
-        try {
-            initialContext = new InitialContext();
-            final Context context = (Context) initialContext.lookup("java:comp/env");
-            return (javax.mail.Session) context.lookup(MAIL_SESSION_NAME);
-        } catch (final NamingException e) {
-            LOGGER.error("Error creating email session: {}", MAIL_SESSION_NAME, e);
-            try {
-                if (initialContext != null) {
-                    initialContext.close();
-                }
-            } catch (final NamingException ignore) {
-                // Silently ignore
-            }
-        }
-
-        return null;
-    }
-
+    /**
+     * Logs the given {@code attribute} and its {@code value} as a debug msg.
+     *
+     * @param attribute the attribute name.
+     * @param value     the value of the attribute.
+     */
     private void logConfiguredAttributeDebugMsg(final String attribute, final String value) {
         LOGGER.debug("Configured attribute: {}={}", attribute, value);
-    }
-
-    /**
-     * Returns CMS/Platform base URL for the given {@code hostGroupName} and the mount alias {@code cms-mount}.
-     *
-     * @return the CMS/Platform base URL for the given  {@code hostGroupName} and the mount alias {@code cms-mount}.
-     */
-    private String getCMSBaseContentURL() {
-        String cmsBaseURL = StringUtils.EMPTY;
-
-        final HstModelRegistry hstModelRegistry = HippoServiceRegistry.getService(HstModelRegistry.class);
-        for (final HstModel hstModel : hstModelRegistry.getHstModels()) {
-            try {
-                final VirtualHosts virtualHosts = hstModel.getVirtualHosts();
-                if (CMS_CONTEXT_PATH.equals(virtualHosts.getContextPath())) {
-                    final String hostGroupName =
-                            StringUtils.isNotBlank(System.getProperty(SYSTEM_PROPERTY_BRC_ENV_NAME)) ?
-                                    HOST_GROUP_BR_CLOUD : HOST_GROUP_DEV_LOCAL_HOST;
-                    LOGGER.debug("'{}' virtual host group has been chosen to build the CMS base URL", hostGroupName);
-
-                    final List<Mount> cmsMounts = hstModel.getVirtualHosts().getMountsByHostGroup(hostGroupName);
-                    if (cmsMounts.isEmpty()) {
-                        LOGGER.warn("Host group '{}' is either unavailable in the current instance " +
-                                "or it doesn't have any mounts", hostGroupName);
-                        return StringUtils.EMPTY;
-                    }
-
-                    final Optional<Mount> cmsMountOpt = cmsMounts.stream()
-                            .filter(mount -> mount.isOfType(Mount.LIVE_NAME))
-                            .findFirst();
-                    final Mount cmsMount = cmsMountOpt.orElse(null);
-                    if (cmsMount == null) {
-                        LOGGER.warn("Host group '{}' doesn't seem to have any live mounts", hostGroupName);
-                        return StringUtils.EMPTY;
-                    }
-
-                    cmsBaseURL = cmsMount.getScheme() +
-                            "://" +
-                            cmsMount.getVirtualHost().getHostName() +
-                            (cmsMount.isPortInUrl() ? ":" + cmsMount.getPort() : StringUtils.EMPTY) +
-                            "/cms/content/path";
-
-                    LOGGER.debug("CMS base URL = {}", cmsBaseURL);
-                }
-            } catch (final Exception e) {
-                LOGGER.error("Caught error '{}' while constructing CMS base URL", e.getMessage(), e);
-            }
-        }
-
-        return cmsBaseURL;
     }
 }

--- a/cms/src/main/java/uk/nhs/hee/web/repository/scheduling/NextReviewDateNotification.java
+++ b/cms/src/main/java/uk/nhs/hee/web/repository/scheduling/NextReviewDateNotification.java
@@ -79,7 +79,8 @@ public class NextReviewDateNotification implements RepositoryJob {
             if (!StringUtils.isBlank(documentTypes)) {
                 // Query documents to be next reviewed
                 final List<Node> documentsToBeReviewed = getDocumentsToBeReviewed(session, documentTypes);
-                LOGGER.info("Documents to be next reviewed = {}", documentsToBeReviewed);
+                LOGGER.debug("Documents to be reviewed = {}", documentsToBeReviewed.stream()
+                        .map(JcrUtils::getNodePathQuietly).collect(Collectors.toList()));
 
                 if (!documentsToBeReviewed.isEmpty()) {
                     // Notify content or channel team
@@ -243,8 +244,8 @@ public class NextReviewDateNotification implements RepositoryJob {
         }
         documentsWithLinksForHTMLBody.append("</ul>");
         // Remove the trailing new line (\n) from the built documents-to-be-reviewed
-        if (documentsWithLinksForPlainTextBody.length() >  0 &&
-                documentsWithLinksForPlainTextBody.charAt(documentsWithLinksForPlainTextBody.length() -  1) == '\n') {
+        if (documentsWithLinksForPlainTextBody.length() > 0 &&
+                documentsWithLinksForPlainTextBody.charAt(documentsWithLinksForPlainTextBody.length() - 1) == '\n') {
             documentsWithLinksForPlainTextBody.setLength(documentsWithLinksForPlainTextBody.length() - 1);
         }
 
@@ -253,6 +254,9 @@ public class NextReviewDateNotification implements RepositoryJob {
                 EMAIL_CONTENT_PLACEHOLDER_DOCUMENTS_WITH_LINKS, documentsWithLinksForHTMLBody.toString());
         formattedEmailBodyPlainText = formattedEmailBodyPlainText.replace(
                 EMAIL_CONTENT_PLACEHOLDER_DOCUMENTS_WITH_LINKS, documentsWithLinksForPlainTextBody.toString());
+
+        LOGGER.debug("Formatted email body HTML: {}", formattedEmailBodyHTML);
+        LOGGER.debug("Formatted email body plain text: {}", formattedEmailBodyPlainText);
 
         return Pair.of(formattedEmailBodyHTML, formattedEmailBodyPlainText);
     }

--- a/cms/src/main/java/uk/nhs/hee/web/repository/scheduling/NextReviewDateNotification.java
+++ b/cms/src/main/java/uk/nhs/hee/web/repository/scheduling/NextReviewDateNotification.java
@@ -1,0 +1,408 @@
+package uk.nhs.hee.web.repository.scheduling;
+
+import com.sun.mail.smtp.SMTPMessage;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.jackrabbit.JcrConstants;
+import org.hippoecm.hst.configuration.hosting.Mount;
+import org.hippoecm.hst.configuration.hosting.VirtualHosts;
+import org.hippoecm.hst.platform.model.HstModel;
+import org.hippoecm.hst.platform.model.HstModelRegistry;
+import org.hippoecm.repository.util.DateTools;
+import org.hippoecm.repository.util.JcrUtils;
+import org.jsoup.Jsoup;
+import org.onehippo.cms7.services.HippoServiceRegistry;
+import org.onehippo.repository.scheduling.RepositoryJob;
+import org.onehippo.repository.scheduling.RepositoryJobExecutionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.mail.*;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMultipart;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class NextReviewDateNotification implements RepositoryJob {
+    // Logger
+    private static final Logger LOGGER = LoggerFactory.getLogger(NextReviewDateNotification.class);
+
+    // 'hee:nextReviewed' property of 'hee:pageLastNextReview' type/node
+    private static final String PROPERTY_NEXT_REVIEWED = "hee:nextReviewed";
+
+    // 'documentTypes' attribute configured on the job
+    private static final String ATTRIBUTE_DOCUMENT_TYPES = "documentTypes";
+
+    // Email attributes configured on the job
+    public static final String ATTRIBUTE_EMAIL_FROM_ADDRESS = "emailFromAddress";
+    public static final String ATTRIBUTE_EMAIL_FROM_NAME = "emailFromName";
+    public static final String ATTRIBUTE_EMAIL_TO_ADDRESSES = "emailToAddresses";
+    public static final String ATTRIBUTE_EMAIL_SUBJECT = "emailSubject";
+    public static final String ATTRIBUTE_EMAIL_BODY_PLAIN_TEXT_TEMPLATE = "emailBodyPlainTextTemplate";
+    public static final String ATTRIBUTE_EMAIL_BODY_HTML_TEMPLATE = "emailBodyHTMLTemplate";
+
+    // Mandatory/required email attributes for the job
+    public static final List<String> REQUIRED_EMAIL_ATTRIBUTES = Arrays.asList(
+            ATTRIBUTE_EMAIL_FROM_ADDRESS,
+            ATTRIBUTE_EMAIL_TO_ADDRESSES,
+            ATTRIBUTE_EMAIL_SUBJECT,
+            ATTRIBUTE_EMAIL_BODY_HTML_TEMPLATE,
+            ATTRIBUTE_EMAIL_BODY_PLAIN_TEXT_TEMPLATE);
+
+    // XPath query template to query the list of documents to be next reviewed
+    private static final String DOCUMENTS_TO_BE_NEXT_REVIEWED_XPATH_QUERY =
+            "/jcr:root/content/documents//element(*, hippo:handle)" +
+                    "/*[(%s) and @hippostd:state='published']/element(hee:pageLastNextReview, hee:pageLastNextReview)" +
+                    "[@%s and @%s = %s]/../..";
+
+    // CMS context path
+    public static final String CMS_CONTEXT_PATH = "/cms";
+
+    // Host groups
+    public static final String HOST_GROUP_BR_CLOUD = "br-cloud";
+    public static final String HOST_GROUP_DEV_LOCAL_HOST = "dev-localhost";
+
+    // 'brc.environmentname' system property
+    public static final String SYSTEM_PROPERTY_BRC_ENV_NAME = "brc.environmentname";
+
+    // Email content/body text placeholders
+    public static final String EMAIL_CONTENT_PLACEHOLDER_NEXT_REVIEW_DATE = "{{next_review_date}}";
+    public static final String EMAIL_CONTENT_PLACEHOLDER_DOCUMENTS_WITH_LINKS = "{{documents_with_links}}";
+
+    // Mail session bind/lookup name
+    public static final String MAIL_SESSION_NAME = "mail/Session";
+
+    // Regular expression to split comma separated values
+    public static final String SPLIT_COMMA_SEPARATED_VALUES_REGEX = "\\s*,\\s*";
+
+    @Override
+    public void execute(final RepositoryJobExecutionContext context) throws RepositoryException {
+        final Session session = context.createSystemSession();
+        try {
+            LOGGER.info("Running next-review-date-notification job");
+
+            // Validate 'documentTypes' attribute
+            final String documentTypes = context.getAttribute(ATTRIBUTE_DOCUMENT_TYPES);
+            logConfiguredAttributeDebugMsg(ATTRIBUTE_DOCUMENT_TYPES, documentTypes);
+
+            if (!StringUtils.isBlank(documentTypes)) {
+                // Query documents to be next reviewed
+                final List<Node> documentsToBeReviewed = getDocumentsToBeReviewed(session, documentTypes);
+                LOGGER.info("Documents to be next reviewed = {}", documentsToBeReviewed);
+
+                if (!documentsToBeReviewed.isEmpty()) {
+                    // Notify content or channel team
+                    notify(context, session, documentsToBeReviewed);
+                } else {
+                    LOGGER.info("There are no documents to be reviewed in the next 14 days!");
+                }
+            } else {
+                LOGGER.warn("Attribute '{}' seems to be either not set or empty. " +
+                                "Please make sure to add '{}' attribute with comma separated list of document types " +
+                                "for which next-review-date notification needs to be sent. Halting the job for now!",
+                        ATTRIBUTE_DOCUMENT_TYPES, ATTRIBUTE_DOCUMENT_TYPES);
+            }
+
+            LOGGER.info("Done executing next-review-date-notification job");
+        } finally {
+            session.logout();
+        }
+    }
+
+    private List<Node> getDocumentsToBeReviewed(final Session session, final String documentTypes)
+            throws RepositoryException {
+        final QueryManager queryManager = session.getWorkspace().getQueryManager();
+        final String formattedQueryString = String.format(
+                DOCUMENTS_TO_BE_NEXT_REVIEWED_XPATH_QUERY,
+                getFormattedPrimaryDocumentTypes(documentTypes),
+                PROPERTY_NEXT_REVIEWED,
+                DateTools.getPropertyForResolution(PROPERTY_NEXT_REVIEWED, DateTools.Resolution.DAY),
+                DateTools.createXPathConstraint(session, get14DaysFromToday(), DateTools.Resolution.DAY));
+        LOGGER.debug("Formatted documents-to-be-next-reviewed query: {}", formattedQueryString);
+
+        final Query query = queryManager.createQuery(formattedQueryString, Query.XPATH);
+        final NodeIterator nodes = query.execute().getNodes();
+
+        final List<Node> documentsToBeReviewed = new ArrayList<>((int) nodes.getSize());
+        while (nodes.hasNext()) {
+            documentsToBeReviewed.add(nodes.nextNode());
+        }
+
+        return documentsToBeReviewed;
+    }
+
+    private String getFormattedPrimaryDocumentTypes(final String documentTypes) {
+        return Arrays.stream(documentTypes.split(SPLIT_COMMA_SEPARATED_VALUES_REGEX))
+                .map(documentType -> String.format("@" + JcrConstants.JCR_PRIMARYTYPE + "='%s'", documentType.trim()))
+                .collect(Collectors.joining(" or "));
+    }
+
+    private Calendar get14DaysFromToday() {
+        final Calendar fourteenDaysFromToday = Calendar.getInstance();
+        fourteenDaysFromToday.add(Calendar.DATE, 14);
+        return fourteenDaysFromToday;
+    }
+
+    private void notify(
+            final RepositoryJobExecutionContext context,
+            final Session session,
+            final List<Node> documentsToBeReviewed) {
+        try {
+            if (!areRequiredEmailAttributesAvailable(context)) {
+                return;
+            }
+
+            // Get email configurations/attributes
+            final String fromEmail = StringUtils.trim(context.getAttribute(ATTRIBUTE_EMAIL_FROM_ADDRESS));
+            final String fromName = StringUtils.defaultString(context.getAttribute(ATTRIBUTE_EMAIL_FROM_NAME));
+            final String toEmails = StringUtils.trim(context.getAttribute(ATTRIBUTE_EMAIL_TO_ADDRESSES));
+            final String subject = StringUtils.trim(context.getAttribute(ATTRIBUTE_EMAIL_SUBJECT));
+            final String bodyHTMLTemplate = StringUtils.trim(context.getAttribute(ATTRIBUTE_EMAIL_BODY_HTML_TEMPLATE));
+            final String bodyPlainTextTemplate =
+                    StringUtils.trim(context.getAttribute(ATTRIBUTE_EMAIL_BODY_PLAIN_TEXT_TEMPLATE));
+
+            // Create message
+            final javax.mail.Session mailSession = getMailSession();
+            if (mailSession == null) {
+                LOGGER.warn("Email session '{}' isn't available. Halting the job for now!", MAIL_SESSION_NAME);
+                return;
+            }
+            final SMTPMessage msg = new SMTPMessage(mailSession);
+
+            // Set from address
+            msg.setFrom(createAddress(fromName, fromEmail));
+
+            // Set sender
+            msg.setSender(createAddress(fromName, fromEmail));
+
+            // Set reply to if needed
+            // msg.setReplyTo();
+
+            // Set envelope from
+            msg.setEnvelopeFrom(fromEmail);
+
+            // Set to/recipient
+            final Address[] addresses = getAddresses(toEmails);
+            msg.addRecipients(Message.RecipientType.TO, addresses);
+
+            // Set subject
+            msg.setSubject(subject);
+
+            // Set content
+            final MimeMultipart mimeAlternativePart = new MimeMultipart("alternative");
+            final Pair<String, String> formattedEmailBody =
+                    formatEmailBody(bodyHTMLTemplate, bodyPlainTextTemplate, documentsToBeReviewed);
+            LOGGER.debug("Formatted email body HTML: {}", formattedEmailBody.getLeft());
+            LOGGER.debug("Formatted email body plain text: {}", formattedEmailBody.getRight());
+
+            // HTML body
+            final BodyPart htmlBodyPart = new MimeBodyPart();
+            htmlBodyPart.setContent(
+                    formattedEmailBody.getLeft(),
+                    "text/html; charset=" + StandardCharsets.UTF_8.name());
+            mimeAlternativePart.addBodyPart(htmlBodyPart);
+
+            // Plain text body
+            final BodyPart textBodyPart = new MimeBodyPart();
+            textBodyPart.setContent(
+                    formattedEmailBody.getRight(),
+                    "text/plain; charset=" + StandardCharsets.UTF_8.name());
+            mimeAlternativePart.addBodyPart(textBodyPart);
+            msg.setContent(mimeAlternativePart);
+
+            // Finally, send
+            Transport.send(msg);
+        } catch(final MessagingException e) {
+            LOGGER.error("Caught error '{}' while preparing and sending the email message", e.getMessage(), e);
+        }
+    }
+
+    private Pair<String, String> formatEmailBody(
+            final String emailBodyHTML,
+            final String emailBodyPlainText,
+            final List<Node> documentsToBeReviewed) {
+        // Format/update '<next_review_date>' placeholder with 14 days from day in 'd MMMM yyyy' format
+        final String formatted14DaysFromToday =
+                new SimpleDateFormat("d MMMM yyyy").format(get14DaysFromToday().getTime());
+        String formattedEmailBodyHTML = emailBodyHTML.replace(
+                EMAIL_CONTENT_PLACEHOLDER_NEXT_REVIEW_DATE, formatted14DaysFromToday);
+        String formattedEmailBodyPlainText = emailBodyPlainText.replace(
+                EMAIL_CONTENT_PLACEHOLDER_NEXT_REVIEW_DATE, formatted14DaysFromToday);
+
+        // Build documents-to-be-reviewed as a list of links
+        final StringBuilder documentsWithLinksForHTMLBody = new StringBuilder("<ul>");
+        final StringBuilder documentsWithLinksForPlainTextBody = new StringBuilder();
+        final String cmsBaseContentURL = getCMSBaseContentURL();
+        for (final Node documentToBeReviewed: documentsToBeReviewed) {
+            try {
+                documentsWithLinksForHTMLBody
+                        .append("<li><a href=\">")
+                        .append(cmsBaseContentURL.isEmpty() ? documentToBeReviewed.getPath() :
+                                cmsBaseContentURL + documentToBeReviewed.getPath())
+                        .append("\">")
+                        .append(JcrUtils.getDisplayNameQuietly(documentToBeReviewed))
+                        .append("</a></li>");
+                documentsWithLinksForPlainTextBody
+                        .append("  - ")
+                        .append(JcrUtils.getDisplayNameQuietly(documentToBeReviewed))
+                        .append(": ")
+                        .append(cmsBaseContentURL.isEmpty() ? documentToBeReviewed.getPath() :
+                                cmsBaseContentURL + documentToBeReviewed.getPath())
+                        .append("\n");
+            } catch (final RepositoryException e) {
+                LOGGER.error("Caught error '{}' while trying to generate CMS link for the document '{}'",
+                        e.getMessage(), JcrUtils.getNodePathQuietly(documentToBeReviewed), e);
+            }
+        }
+        documentsWithLinksForHTMLBody.append("</ul>");
+        // Remove the trailing new line (\n) from the built documents-to-be-reviewed
+        if (documentsWithLinksForPlainTextBody.length() >  0 &&
+                documentsWithLinksForPlainTextBody.charAt(documentsWithLinksForPlainTextBody.length() -  1) == '\n') {
+            documentsWithLinksForPlainTextBody.setLength(documentsWithLinksForPlainTextBody.length() -  1);
+        }
+
+        // Finally, format/update '<documents_with_links>' placeholder with a list of document links to be reviewed.
+        formattedEmailBodyHTML = formattedEmailBodyHTML.replace(
+                EMAIL_CONTENT_PLACEHOLDER_DOCUMENTS_WITH_LINKS, documentsWithLinksForHTMLBody.toString());
+        formattedEmailBodyPlainText = formattedEmailBodyPlainText.replace(
+                EMAIL_CONTENT_PLACEHOLDER_DOCUMENTS_WITH_LINKS, documentsWithLinksForPlainTextBody.toString());
+
+        return Pair.of(formattedEmailBodyHTML, formattedEmailBodyPlainText);
+    }
+
+    private String convertToEmailPlainBodyText(final String emailBodyHTML) {
+        return Jsoup.parse(emailBodyHTML).wholeText();
+    }
+
+    private boolean areRequiredEmailAttributesAvailable(final RepositoryJobExecutionContext context) {
+        final List<String> blankEmailAttributes = new ArrayList<>();
+        for (final String attributeName: REQUIRED_EMAIL_ATTRIBUTES) {
+            final String emailAttributeValue = context.getAttribute(attributeName);
+            logConfiguredAttributeDebugMsg(attributeName, emailAttributeValue);
+
+            if (StringUtils.isBlank(emailAttributeValue)) {
+                blankEmailAttributes.add(attributeName);
+            }
+        }
+
+        if (!blankEmailAttributes.isEmpty()) {
+            LOGGER.warn("Email specific attributes {} seem to have been either not set or empty on the job. " +
+                            "Please make sure to add {} email attributes with appropriate values on the job. " +
+                            "Halting the job for now!",
+                    blankEmailAttributes, blankEmailAttributes);
+            return false;
+        }
+
+        return true;
+    }
+
+    private Address[] getAddresses(final String toEmails) {
+        return Arrays.stream(toEmails.split(SPLIT_COMMA_SEPARATED_VALUES_REGEX))
+                .map(address -> createAddress(null, address))
+                .toArray(Address[]::new);
+    }
+
+    public static Address createAddress(final String name, final String email) {
+        try {
+            if (StringUtils.isEmpty(name)) {
+                return new InternetAddress(email);
+            }
+
+            return new InternetAddress(email, name);
+        } catch (final UnsupportedEncodingException | AddressException e) {
+            LOGGER.error("Caught error '{}' while creating email address with name='{}' and email='{}'",
+                    e.getMessage(), name, email, e);
+        }
+
+        return null;
+    }
+
+    private javax.mail.Session getMailSession() {
+        Context initialContext = null;
+
+        try {
+            initialContext = new InitialContext();
+            final Context context = (Context) initialContext.lookup("java:comp/env");
+            return (javax.mail.Session) context.lookup(MAIL_SESSION_NAME);
+        } catch (final NamingException e) {
+            LOGGER.error("Error creating email session: {}", MAIL_SESSION_NAME, e);
+            try {
+                if (initialContext != null) {
+                    initialContext.close();
+                }
+            } catch (final NamingException ignore) {
+                // Silently ignore
+            }
+        }
+
+        return null;
+    }
+
+    private void logConfiguredAttributeDebugMsg(final String attribute, final String value) {
+        LOGGER.debug("Configured attribute: {}={}", attribute, value);
+    }
+
+    /**
+     * Returns CMS/Platform base URL for the given {@code hostGroupName} and the mount alias {@code cms-mount}.
+     *
+     * @return the CMS/Platform base URL for the given  {@code hostGroupName} and the mount alias {@code cms-mount}.
+     */
+    private String getCMSBaseContentURL() {
+        String cmsBaseURL = StringUtils.EMPTY;
+
+        final HstModelRegistry hstModelRegistry = HippoServiceRegistry.getService(HstModelRegistry.class);
+        for (final HstModel hstModel : hstModelRegistry.getHstModels()) {
+            try {
+                final VirtualHosts virtualHosts = hstModel.getVirtualHosts();
+                if (CMS_CONTEXT_PATH.equals(virtualHosts.getContextPath())) {
+                    final String hostGroupName =
+                            StringUtils.isNotBlank(System.getProperty(SYSTEM_PROPERTY_BRC_ENV_NAME)) ?
+                                    HOST_GROUP_BR_CLOUD : HOST_GROUP_DEV_LOCAL_HOST;
+                    LOGGER.debug("'{}' virtual host group has been chosen to build the CMS base URL", hostGroupName);
+
+                    final List<Mount> cmsMounts = hstModel.getVirtualHosts().getMountsByHostGroup(hostGroupName);
+                    if (cmsMounts.isEmpty()) {
+                        LOGGER.warn("Host group '{}' is either unavailable in the current instance " +
+                                "or it doesn't have any mounts", hostGroupName);
+                        return StringUtils.EMPTY;
+                    }
+
+                    final Optional<Mount> cmsMountOpt = cmsMounts.stream()
+                            .filter(mount -> mount.isOfType(Mount.LIVE_NAME))
+                            .findFirst();
+                    final Mount cmsMount = cmsMountOpt.orElse(null);
+                    if (cmsMount == null) {
+                        LOGGER.warn("Host group '{}' doesn't seem to have any live mounts", hostGroupName);
+                        return StringUtils.EMPTY;
+                    }
+
+                    cmsBaseURL = cmsMount.getScheme() +
+                            "://" +
+                            cmsMount.getVirtualHost().getHostName() +
+                            (cmsMount.isPortInUrl() ? ":" + cmsMount.getPort() : StringUtils.EMPTY) +
+                            "/cms/content/path";
+
+                    LOGGER.debug("CMS base URL = {}", cmsBaseURL);
+                }
+            } catch (final Exception e) {
+                LOGGER.error("Caught error '{}' while constructing CMS base URL", e.getMessage(), e);
+            }
+        }
+
+        return cmsBaseURL;
+    }
+}

--- a/cms/src/main/java/uk/nhs/hee/web/utils/DocumentUtils.java
+++ b/cms/src/main/java/uk/nhs/hee/web/utils/DocumentUtils.java
@@ -1,14 +1,36 @@
 package uk.nhs.hee.web.utils;
 
+import org.apache.commons.lang3.StringUtils;
+import org.hippoecm.hst.configuration.hosting.Mount;
+import org.hippoecm.hst.configuration.hosting.VirtualHosts;
+import org.hippoecm.hst.platform.model.HstModel;
+import org.hippoecm.hst.platform.model.HstModelRegistry;
 import org.hippoecm.repository.api.HippoNodeType;
+import org.onehippo.cms7.services.HippoServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Utility class for documents.
  */
 public class DocumentUtils {
+    // Logger
+    private static final Logger LOGGER = LoggerFactory.getLogger(DocumentUtils.class);
+
+    // CMS context path
+    public static final String CMS_CONTEXT_PATH = "/cms";
+
+    // 'brc.environmentname' system property
+    public static final String SYSTEM_PROPERTY_BRC_ENV_NAME = "brc.environmentname";
+
+    // Host groups
+    public static final String HOST_GROUP_BR_CLOUD = "br-cloud";
+    public static final String HOST_GROUP_DEV_LOCAL_HOST = "dev-localhost";
 
     /**
      * Private constructor to hide the implicit public one.
@@ -28,6 +50,61 @@ public class DocumentUtils {
     public static String getDocumentDisplayName(final Session session, final String documentId)
             throws RepositoryException {
         return session.getNodeByIdentifier(documentId).getProperty(HippoNodeType.HIPPO_NAME).getString();
+    }
+
+    /**
+     * Returns CMS/Platform document base URL for the current environment (local/brCloud).
+     *
+     * <p>It checks for the existence of  {@code brc.environmentname} system property to identify
+     * if the current environment is {@code brCloud} or {@code local}. If {@code brCloud}, uses {@code br-cloud}
+     * host group to generate the document base URL. Otherwise, assumes that the environment is {@code local}
+     * and uses {@code dev-localhost} to generate the document base URL.</p>
+     *
+     * @return the CMS/Platform document base URL for the current environment (local/brCloud).
+     */
+    public static String getDocumentBaseURL() {
+        String cmsBaseURL = StringUtils.EMPTY;
+
+        final HstModelRegistry hstModelRegistry = HippoServiceRegistry.getService(HstModelRegistry.class);
+        for (final HstModel hstModel : hstModelRegistry.getHstModels()) {
+            try {
+                final VirtualHosts virtualHosts = hstModel.getVirtualHosts();
+                if (CMS_CONTEXT_PATH.equals(virtualHosts.getContextPath())) {
+                    final String hostGroupName =
+                            StringUtils.isNotBlank(System.getProperty(SYSTEM_PROPERTY_BRC_ENV_NAME)) ?
+                                    HOST_GROUP_BR_CLOUD : HOST_GROUP_DEV_LOCAL_HOST;
+                    LOGGER.debug("'{}' virtual host group has been chosen to build the CMS base URL", hostGroupName);
+
+                    final List<Mount> cmsMounts = hstModel.getVirtualHosts().getMountsByHostGroup(hostGroupName);
+                    if (cmsMounts.isEmpty()) {
+                        LOGGER.warn("Host group '{}' is either unavailable in the current instance " +
+                                "or it doesn't have any mounts", hostGroupName);
+                        return StringUtils.EMPTY;
+                    }
+
+                    final Optional<Mount> cmsMountOpt = cmsMounts.stream()
+                            .filter(mount -> mount.isOfType(Mount.LIVE_NAME))
+                            .findFirst();
+                    final Mount cmsMount = cmsMountOpt.orElse(null);
+                    if (cmsMount == null) {
+                        LOGGER.warn("Host group '{}' doesn't seem to have any live mounts", hostGroupName);
+                        return StringUtils.EMPTY;
+                    }
+
+                    cmsBaseURL = cmsMount.getScheme() +
+                            "://" +
+                            cmsMount.getVirtualHost().getHostName() +
+                            (cmsMount.isPortInUrl() ? ":" + cmsMount.getPort() : StringUtils.EMPTY) +
+                            "/cms/content/path";
+
+                    LOGGER.debug("CMS base URL = {}", cmsBaseURL);
+                }
+            } catch (final Exception e) {
+                LOGGER.error("Caught error '{}' while constructing CMS base URL", e.getMessage(), e);
+            }
+        }
+
+        return cmsBaseURL;
     }
 
 }

--- a/cms/src/main/java/uk/nhs/hee/web/utils/MailUtils.java
+++ b/cms/src/main/java/uk/nhs/hee/web/utils/MailUtils.java
@@ -1,0 +1,95 @@
+package uk.nhs.hee.web.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.mail.Address;
+import javax.mail.Session;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class containing mail utility methods.
+ */
+public class MailUtils {
+    // Logger
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailUtils.class);
+
+    // Mail session bind/lookup name
+    private static final String MAIL_SESSION_NAME = "mail/Session";
+
+    /**
+     * Private constructor to hide the implicit public one.
+     */
+    private MailUtils() {
+    }
+
+    /**
+     * Returns the given comma separated email addresses {@code commaSeparatedEmails} as {@link List<Address>}.
+     *
+     * @param commaSeparatedEmails the comma separated email addresses.
+     * @return the {@link List<Address>} built from the given comma separated email addresses
+     * {@code commaSeparatedEmails}.
+     */
+    public static List<Address> getAddresses(final String commaSeparatedEmails) {
+        return uk.nhs.hee.web.utils.StringUtils.transformCommaSeparatedStringIntoStringList(commaSeparatedEmails)
+                .map(address -> createAddress(null, address))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Return {@link Address} for the given personal {@code name} and {@code email} address.
+     *
+     * @param name the personal name for the email address.
+     * @param email the email address.
+     * @return the {@link Address} for the given personal {@code name} and {@code email} address.
+     */
+    public static Address createAddress(final String name, final String email) {
+        try {
+            if (StringUtils.isEmpty(name)) {
+                return new InternetAddress(email);
+            }
+
+            return new InternetAddress(email, name);
+        } catch (final UnsupportedEncodingException | AddressException e) {
+            LOGGER.error("Caught error '{}' while creating email address with name='{}' and email='{}'",
+                    e.getMessage(), name, email, e);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the mail {@link Session} from the JNDI lookup.
+     *
+     * @return the mail {@link Session} from the JNDI lookup.
+     */
+    public static Session getMailSession() {
+        Context initialContext = null;
+
+        try {
+            initialContext = new InitialContext();
+            final Context context = (Context) initialContext.lookup("java:comp/env");
+            return (javax.mail.Session) context.lookup(MAIL_SESSION_NAME);
+        } catch (final NamingException e) {
+            LOGGER.error("Error creating email session: {}", MAIL_SESSION_NAME, e);
+            try {
+                if (initialContext != null) {
+                    initialContext.close();
+                }
+            } catch (final NamingException ignore) {
+                // Silently ignore
+            }
+        }
+
+        LOGGER.warn("Email session '{}' isn't available", MAIL_SESSION_NAME);
+        return null;
+    }
+}

--- a/cms/src/main/java/uk/nhs/hee/web/utils/StringUtils.java
+++ b/cms/src/main/java/uk/nhs/hee/web/utils/StringUtils.java
@@ -1,0 +1,34 @@
+package uk.nhs.hee.web.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.stream.Stream;
+
+/**
+ * Class containing {@code String} utility methods.
+ */
+public class StringUtils {
+    // Logger
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringUtils.class);
+
+    // Regular expression to split comma separated values
+    private static final String SPLIT_COMMA_SEPARATED_VALUES_REGEX = "\\s*,\\s*";
+
+    /**
+     * Private constructor to hide the implicit public one.
+     */
+    private StringUtils() {
+    }
+
+    /**
+     * Returns the given comma separated values {@code commaSeparatedValues} as a {@link Stream<String>}.
+     *
+     * @param commaSeparatedValues the comma separated values.
+     * @return the {@link Stream<String>} extracted from the given comma separated string {@code commaSeparatedValues}.
+     */
+    public static Stream<String> transformCommaSeparatedStringIntoStringList(final String commaSeparatedValues) {
+        return Stream.of(commaSeparatedValues.split(SPLIT_COMMA_SEPARATED_VALUES_REGEX));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
 
                   <!-- Example to pass JavaMail connection factory JNDI resource attribute values as system properties -->
                   <!-- Alternatively these could directly be configured on 'conf/context-dev.xml'  -->
-                  <!-- <mail.smtp.host><<mail.smtp.host>></mail.smtp.host></mail.smtp.host>
+                  <!-- <mail.smtp.host><<mail.smtp.host>></mail.smtp.host>
                   <mail.smtp.port><<mail.smtp.port>></mail.smtp.port>
                   <mail.smtp.user><<mail.smtp.user>></mail.smtp.user>
                   <mail.smtp.password><<mail.smtp.password>></mail.smtp.password>

--- a/pom.xml
+++ b/pom.xml
@@ -497,7 +497,7 @@
                   <mail.smtp.port><<mail.smtp.port>></mail.smtp.port>
                   <mail.smtp.user><<mail.smtp.user>></mail.smtp.user>
                   <mail.smtp.password><<mail.smtp.password>></mail.smtp.password>
-                  <mail.smtp.auth><<mail.smtp.authv</mail.smtp.auth>
+                  <mail.smtp.auth><<mail.smtp.auth>></mail.smtp.auth>
                   <mail.smtp.starttls.enable><<mail.smtp.starttls.enable>></mail.smtp.starttls.enable> -->
                 </systemProperties>
               </container>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
@@ -6,23 +6,21 @@ definitions:
         jcr:primaryType: hipposched:repositoryjob
         hipposched:attributeNames: [documentTypes, emailFromAddress, emailFromName,
           emailToAddresses, emailSubject, emailBodyHTMLTemplate, emailBodyPlainTextTemplate]
-        hipposched:attributeValues: ['hee:blogPost,hee:guidance,hee:news,hee:report,hee:trainingProgrammePage',
-          <<from_email_address>>, Do not reply, <<comma_separated_to_email_addresses>>,
-          '[Action required] Documents review', "<!DOCTYPE html>\r\n<html lang=\"\
-            en\">\r\n    <head>\r\n        <meta charset=\"UTF-8\">\r\n        <title>Documents\
-            \ next review date email notification</title>\r\n    </head>\r\n    <body>\r\
-            \n        <p>Dear Content Team,</p>\r\n        <p>This is a gentle reminder\
+        hipposched:attributeValues: ['hee:blogPost,hee:guidance,hee:report,hee:trainingProgrammePage',
+          nwpsupport@hee.nhs.uk, Do not reply, nwpsupport@hee.nhs.uk, '[Action required]
+            Documents review', "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n    <head>\r\
+            \n        <meta charset=\"UTF-8\">\r\n        <title>Documents next review\
+            \ date email notification</title>\r\n    </head>\r\n    <body>\r\n   \
+            \     <p>Dear Content Team,</p>\r\n        <p>This is a gentle reminder\
             \ that the next review dates for the following documents are commencing\
-            \ in 14 days.\r\n            Please make sure to review them on or before\
-            \ {{next_review_date}}.</p>\r\n        {{documents_with_links}}\r\n  \
-            \      <p>Thank you,<br>NWP Support</p>\r\n        <p><small>Note: This\
-            \ is an automated email. Please do not reply, as this mailbox is not monitored.</small></p>\r\
+            \ in 14 to 21 days.\r\n            Please make sure to review them.</p>\r\
+            \n        {{documents_with_links}}\r\n        <p>Thank you,<br>NWP Support</p>\r\
+            \n        <p><small>Note: This is an automated email. Please do not reply.</small></p>\r\
             \n    </body>\r\n</html>", "Dear Content Team,\r\n\r\nThis is a gentle\
             \ reminder that the next review dates for the following documents are\
-            \ commencing in 14 days. Please make sure to review them on or before\
-            \ {{next_review_date}}.\r\n\r\n{{documents_with_links}}\r\n\r\nThank you,\r\
-            \nNWP Support\r\n\r\nNote: This is an automated email. Please do not reply,\
-            \ as this mailbox is not monitored."]
+            \ commencing in 14 to 21 days. Please make sure to review them.\r\n\r\n\
+            {{documents_with_links}}\r\n\r\nThank you,\r\nNWP Support\r\n\r\nNote:\
+            \ This is an automated email. Please do not reply."]
         hipposched:enabled: true
         hipposched:repositoryJobClass: uk.nhs.hee.web.repository.scheduling.NextReviewDateNotification
         /hipposched:triggers:
@@ -31,6 +29,6 @@ definitions:
             jcr:primaryType: hipposched:crontrigger
             jcr:mixinTypes: ['mix:lockable']
             jcr:uuid: 40869f2d-3f45-4710-a125-db5c0d8bad36
-            hipposched:cronExpression: 0 0 5 * * ?
+            hipposched:cronExpression: 0 0 4 ? * FRI *
             hipposched:enabled: true
-            hipposched:nextFireTime: 2024-02-13T05:00:00Z
+            hipposched:nextFireTime: 2024-03-01T04:00:00Z

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
@@ -5,13 +5,14 @@ definitions:
       /NextReviewDateNotification:
         jcr:primaryType: hipposched:repositoryjob
         hipposched:attributeNames: [documentTypes, emailFromAddress, emailFromName,
-          emailToAddresses, emailSubject, emailBodyHTMLTemplate, emailBodyPlainTextTemplate]
+          emailReplyToAddress, emailToAddresses, emailSubject, emailBodyHTMLTemplate,
+          emailBodyPlainTextTemplate]
         hipposched:attributeValues: ['hee:blogPost,hee:guidance,hee:report,hee:trainingProgrammePage',
-          nwpsupport@hee.nhs.uk, Do not reply, nwpsupport@hee.nhs.uk, '[Action required]
-            Documents review', "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n    <head>\r\
-            \n        <meta charset=\"UTF-8\">\r\n        <title>Documents next review\
-            \ date email notification</title>\r\n    </head>\r\n    <body>\r\n   \
-            \     <p>Dear Content Team,</p>\r\n        <p>This is a gentle reminder\
+          nwpsupport@hee.nhs.uk, Do not reply, nwpsupport@hee.nhs.uk, nwpsupport@hee.nhs.uk,
+          '[Action required] Documents review', "<!DOCTYPE html>\r\n<html lang=\"\
+            en\">\r\n    <head>\r\n        <meta charset=\"UTF-8\">\r\n        <title>Documents\
+            \ next review date email notification</title>\r\n    </head>\r\n    <body>\r\
+            \n        <p>Dear Content Team,</p>\r\n        <p>This is a gentle reminder\
             \ that the next review dates for the following documents are commencing\
             \ in 14 to 21 days.\r\n            Please make sure to review them.</p>\r\
             \n        {{documents_with_links}}\r\n        <p>Thank you,<br>NWP Support</p>\r\

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
@@ -6,25 +6,24 @@ definitions:
         jcr:primaryType: hipposched:repositoryjob
         hipposched:attributeNames: [documentTypes, emailFromAddress, emailFromName,
           emailToAddresses, emailSubject, emailBodyHTMLTemplate, emailBodyPlainTextTemplate]
-        hipposched:attributeValues: ['hee:blogPost, hee:guidance, hee:news, hee:report,
-            hee:trainingProgrammePage', unknown-email@unknowndomain.com, Do not reply,
-          unknown-email@unknowndomain.com, '[Action required] Documents review', "<!DOCTYPE\
-            \ html>\r\n<html lang=\"en\">\r\n    <head>\r\n        <meta charset=\"\
-            UTF-8\">\r\n        <title>Documents next review date email notification</title>\r\
-            \n    </head>\r\n    <body>\r\n        <p>Dear Content Team,</p>\r\n \
-            \       <p>This is a gentle reminder that the next review dates for the\
-            \ following documents are commencing in 14 days.\r\n            Please\
-            \ make sure to review them on or before {{next_review_date}}.</p>\r\n\
-            \        {{documents_with_links}}\r\n        <p>Thank you,<br>NWP Support</p>\r\
-            \n        <p><small>Note: This is an automated email. Please do not reply,\
-            \ as this mailbox is not monitored.</small></p>\r\n    </body>\r\n</html>",
-          "Dear Content Team,\r\n\r\nThis is a gentle reminder that the next review\
-            \ dates for the following documents are commencing in 14 days. Please\
-            \ make sure to review them on or before {{next_review_date}}.\r\n\r\n\
-            {{documents_with_links}}\r\n\r\nThank you,\r\nNWP Support\r\n\r\nNote:\
-            \ This is an automated email. Please do not reply, as this mailbox is\
-            \ not monitored."]
-        hipposched:enabled: false
+        hipposched:attributeValues: ['hee:blogPost,hee:guidance,hee:news,hee:report,hee:trainingProgrammePage',
+          <<from_email_address>>, Do not reply, <<comma_separated_to_email_addresses>>,
+          '[Action required] Documents review', "<!DOCTYPE html>\r\n<html lang=\"\
+            en\">\r\n    <head>\r\n        <meta charset=\"UTF-8\">\r\n        <title>Documents\
+            \ next review date email notification</title>\r\n    </head>\r\n    <body>\r\
+            \n        <p>Dear Content Team,</p>\r\n        <p>This is a gentle reminder\
+            \ that the next review dates for the following documents are commencing\
+            \ in 14 days.\r\n            Please make sure to review them on or before\
+            \ {{next_review_date}}.</p>\r\n        {{documents_with_links}}\r\n  \
+            \      <p>Thank you,<br>NWP Support</p>\r\n        <p><small>Note: This\
+            \ is an automated email. Please do not reply, as this mailbox is not monitored.</small></p>\r\
+            \n    </body>\r\n</html>", "Dear Content Team,\r\n\r\nThis is a gentle\
+            \ reminder that the next review dates for the following documents are\
+            \ commencing in 14 days. Please make sure to review them on or before\
+            \ {{next_review_date}}.\r\n\r\n{{documents_with_links}}\r\n\r\nThank you,\r\
+            \nNWP Support\r\n\r\nNote: This is an automated email. Please do not reply,\
+            \ as this mailbox is not monitored."]
+        hipposched:enabled: true
         hipposched:repositoryJobClass: uk.nhs.hee.web.repository.scheduling.NextReviewDateNotification
         /hipposched:triggers:
           jcr:primaryType: hipposched:triggers
@@ -32,5 +31,6 @@ definitions:
             jcr:primaryType: hipposched:crontrigger
             jcr:mixinTypes: ['mix:lockable']
             jcr:uuid: 40869f2d-3f45-4710-a125-db5c0d8bad36
-            hipposched:cronExpression: 0 * * * * ?
+            hipposched:cronExpression: 0 0 5 * * ?
             hipposched:enabled: true
+            hipposched:nextFireTime: 2024-02-13T05:00:00Z

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
@@ -1,0 +1,36 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:modules/scheduler/hippo:moduleconfig/custom:
+      jcr:primaryType: hipposched:jobgroup
+      /NextReviewDateNotification:
+        jcr:primaryType: hipposched:repositoryjob
+        hipposched:attributeNames: [documentTypes, emailFromAddress, emailFromName,
+          emailToAddresses, emailSubject, emailBodyHTMLTemplate, emailBodyPlainTextTemplate]
+        hipposched:attributeValues: ['hee:blogPost, hee:guidance, hee:news, hee:report,
+            hee:trainingProgrammePage', unknown-email@unknowndomain.com, Do not reply,
+          unknown-email@unknowndomain.com, '[Action required] Documents review', "<!DOCTYPE\
+            \ html>\r\n<html lang=\"en\">\r\n    <head>\r\n        <meta charset=\"\
+            UTF-8\">\r\n        <title>Documents next review date email notification</title>\r\
+            \n    </head>\r\n    <body>\r\n        <p>Dear Content Team,</p>\r\n \
+            \       <p>This is a gentle reminder that the next review dates for the\
+            \ following documents are commencing in 14 days.\r\n            Please\
+            \ make sure to review them on or before {{next_review_date}}.</p>\r\n\
+            \        {{documents_with_links}}\r\n        <p>Thank you,<br>NWP Support</p>\r\
+            \n        <p><small>Note: This is an automated email. Please do not reply,\
+            \ as this mailbox is not monitored.</small></p>\r\n    </body>\r\n</html>",
+          "Dear Content Team,\r\n\r\nThis is a gentle reminder that the next review\
+            \ dates for the following documents are commencing in 14 days. Please\
+            \ make sure to review them on or before {{next_review_date}}.\r\n\r\n\
+            {{documents_with_links}}\r\n\r\nThank you,\r\nNWP Support\r\n\r\nNote:\
+            \ This is an automated email. Please do not reply, as this mailbox is\
+            \ not monitored."]
+        hipposched:enabled: false
+        hipposched:repositoryJobClass: uk.nhs.hee.web.repository.scheduling.NextReviewDateNotification
+        /hipposched:triggers:
+          jcr:primaryType: hipposched:triggers
+          /nightly:
+            jcr:primaryType: hipposched:crontrigger
+            jcr:mixinTypes: ['mix:lockable']
+            jcr:uuid: 40869f2d-3f45-4710-a125-db5c0d8bad36
+            hipposched:cronExpression: 0 * * * * ?
+            hipposched:enabled: true

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/queue/DisableNextReviewDateNotificationJobOnNonProdEnvironments.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/queue/DisableNextReviewDateNotificationJobOnNonProdEnvironments.yaml
@@ -1,0 +1,43 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:queue/DisableNextReviewDateNotificationJobOnNonProdEnvironments:
+      jcr:primaryType: hipposys:updaterinfo
+      hipposys:batchsize: 1
+      hipposys:description: Disables 'NextReviewDateNotification' repository job on
+        non-prod environments after repository data bootstrapping.
+      hipposys:dryrun: false
+      hipposys:loglevel: INFO
+      hipposys:logtarget: LOG FILES
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/hippo:configuration/hippo:modules/scheduler/hippo:moduleconfig/custom/NextReviewDateNotification
+      hipposys:script: "package org.hippoecm.frontend.plugins.cms.admin.updater\r\n\
+        \r\nimport org.apache.commons.lang3.StringUtils\r\nimport org.onehippo.repository.update.BaseNodeUpdateVisitor\r\
+        \n\r\nimport javax.jcr.Node\r\n\r\nclass DisableNextReviewDateNotificationJobOnNonProdEnvironments\
+        \ extends BaseNodeUpdateVisitor {\r\n    // 'brc.environmentname' system property\r\
+        \n    public static final String SYSTEM_PROPERTY_BRC_ENV_NAME = \"brc.environmentname\"\
+        ;\r\n\r\n    // 'brc.environmentname' system property value on prod environment\r\
+        \n    public static final String PROD_BRC_ENV_NAME_VALUE = \"production\"\
+        ;\r\n\r\n    // 'hipposched:enabled' hippo scheduler property\r\n    public\
+        \ static final String PROPERTY_HIPPO_SCHEDULER_ENABLED = \"hipposched:enabled\"\
+        ;\r\n\r\n    // cron trigger node path for 'NextReviewDateNotification' custom\
+        \ repository job\r\n    public static final String NODE_NEXT_REVIEW_DATE_NOTIFICATION_CRON_TRIGGER\
+        \ = \"hipposched:triggers/nightly\";\r\n\r\n    boolean doUpdate(Node node)\
+        \ {\r\n        node.setProperty(PROPERTY_HIPPO_SCHEDULER_ENABLED, Boolean.FALSE)\r\
+        \n        node.getNode(NODE_NEXT_REVIEW_DATE_NOTIFICATION_CRON_TRIGGER)\r\n\
+        \                .setProperty(PROPERTY_HIPPO_SCHEDULER_ENABLED, Boolean.FALSE)\r\
+        \n\r\n        // Disables both 'NextReviewDateNotification' custom repository\
+        \ job and its trigger for non-prod environments.\r\n        if (StringUtils.isBlank(System.getProperty(SYSTEM_PROPERTY_BRC_ENV_NAME))\r\
+        \n                || PROD_BRC_ENV_NAME_VALUE != System.getProperty(SYSTEM_PROPERTY_BRC_ENV_NAME))\
+        \ {\r\n            log.info \"It's a non-prod environment \" +\r\n       \
+        \             \"and so disabling 'NextReviewDateNotification' (/hippo:configuration/hippo:modules/scheduler\"\
+        \ +\r\n                    \"/hippo:moduleconfig/custom/NextReviewDateNotification)\
+        \ custom repository job and its (cron) trigger\"\r\n            // Disabling\
+        \ the job\r\n            node.setProperty(PROPERTY_HIPPO_SCHEDULER_ENABLED,\
+        \ Boolean.FALSE)\r\n\r\n            if (node.hasNode(NODE_NEXT_REVIEW_DATE_NOTIFICATION_CRON_TRIGGER))\
+        \ {\r\n                // Disabling the trigger\r\n                node.getNode(NODE_NEXT_REVIEW_DATE_NOTIFICATION_CRON_TRIGGER)\r\
+        \n                        .setProperty(PROPERTY_HIPPO_SCHEDULER_ENABLED, Boolean.FALSE)\r\
+        \n            }\r\n\r\n            return true\r\n        }\r\n\r\n      \
+        \  return false\r\n    }\r\n\r\n    boolean undoUpdate(Node node) {\r\n  \
+        \      throw new UnsupportedOperationException('Updater does not implement\
+        \ undoUpdate method')\r\n    }\r\n\r\n}"
+      hipposys:throttle: 1000


### PR DESCRIPTION
- A custom repository job `/hippo:configuration/hippo:modules/scheduler/hippo:moduleconfig/custom/NextReviewDateNotification` has been added to search for page documents which require reviewing in the `next 14 - 21 days` i.e. page documents (like `Standard content page`, `Blog post`, etc) whose `hee:pageLastNextReview/@hee:nextReviewed` date falls between the next `14 - 21 days`.
- The repository job `NextReviewDateNotification` has been scheduled to run `weekly on Friday morning at 4`.
- Page document types which needs to be searched for the next reviewed date and email notification settings have been configured under `NextReviewDateNotification` job (as `hipposched:attributeNames` and `hipposched:attributeValues` properties).
- CI/CD pipelines i.e. Github workflow jobs have been configured to deploy the application with `hee-smtp.properties` system property file on `brCloud` environments to set up `SMTP` related system properties to send email notification.
- Added a `DisableNextReviewDateNotificationJobOnNonProdEnvironments` updater script under `/hippo:configuration/hippo:update/hippo:queue` so that it will disable `NextReviewDateNotification` repository job and its (cron) trigger on non-prod environments during startup.