### PR TITLE
[NWPS-1502] Search engine optimisation for search results and listing/collection page

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/searchresults.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/searchresults.yaml
@@ -7,7 +7,7 @@ definitions:
         jcr:primaryType: hst:component
         hst:componentclassname: uk.nhs.hee.web.components.SearchResultsComponent
         hst:parameternames: [document, invalidSearchTerms]
-        hst:parametervalues: [listing-pages/search-results, 'cheapfifa23coins,fifa2022,seo4now']
+        hst:parametervalues: [listing-pages/search-results, 'cheapfifa23coins,fifa2022,seo4now,dcdgame']
         hst:template: searchresults-main
       /header:
         jcr:primaryType: hst:component

--- a/repository-data/webfiles/src/main/resources/site/freemarker/include/page-meta-data.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/include/page-meta-data.ftl
@@ -2,6 +2,8 @@
 <#include "../include/imports.ftl">
 <@hst.defineObjects />
 
+<#assign addNoIndexRobotsTag=false>
+
 <#if document??>
     <#if document.contentType = 'hee:MiniHub' && currentGuidance??>
         <#--  For Mini-hub, generates meta title and description based on child Standard content page document's Title and Summary  -->
@@ -19,55 +21,83 @@
         </#if>
     <#else>
         <#assign pageTitle="${hstRequestContext.resolvedSiteMapItem.pageTitle?has_content?then(hstRequestContext.resolvedSiteMapItem.pageTitle, document.title!)}">
+
         <#if document.contentType = 'hee:trainingProgrammesHomepage'>
             <#assign pageSummary="${document.programmeDescription!}">
         <#else>
             <#assign pageSummary="${document.summary!}">
         </#if>
+
         <@hst.link var="pageURL" hippobean=document canonical=true fullyQualified=true />
     </#if>
+
+    <#assign addNoIndexRobotsTag=(['hee:listingPage', 'hee:publicationListingPage']?seq_contains(document.contentType))?then(true, false)>
 </#if>
 
 <#assign metaTitle>${(pageTitle?has_content)?then(pageTitle+' | '+hstRequestContext.resolvedMount.mount.channelInfo.organisationName, '')}</#assign>
 
+<#--  Meta tags: START  -->
+<#--  Title  -->
 <#if metaTitle?has_content>
     <@hst.headContribution category="pageMetaData">
         <meta name="title" content="${metaTitle}" />
     </@hst.headContribution>
 </#if>
 
+<#--  Description  -->
 <#if pageSummary?has_content>
     <@hst.headContribution category="pageMetaData">
         <meta name="description" content="${pageSummary}" />
     </@hst.headContribution>
 </#if>
 
+<#--  Robots  -->
+<#if addNoIndexRobotsTag>
+    <@hst.headContribution category="pageMetaData">
+        <meta name="robots" content="noindex" />
+    </@hst.headContribution>
+</#if>
+<#--  Meta tags: END  -->
+
+<#--  Open Graph meta tags: START  -->
+<#--  Title  -->
 <#if metaTitle?has_content>
     <@hst.headContribution category="pageMetaData">
         <meta property="og:title" content="${metaTitle}" />
     </@hst.headContribution>
 </#if>
 
+<#--  Description  -->
 <#if pageSummary?has_content>
     <@hst.headContribution category="pageMetaData">
         <meta property="og:description" content="${pageSummary}" />
     </@hst.headContribution>
 </#if>
 
+<#--  Canonical URL  -->
 <#if pageURL?? && pageURL?has_content>
     <@hst.headContribution category="pageMetaData">
         <meta property="og:url" content="${pageURL!}" />
     </@hst.headContribution>
 </#if>
 
+<#--  Type  -->
 <@hst.headContribution category="pageMetaData">
     <meta property="og:type" content="website" />
 </@hst.headContribution>
 
+<#--  Image  -->
 <@hst.headContribution category="pageMetaData">
     <meta property="og:image" content="<@hst.link path='/static/assets/images/logos/hee-logo.png' fullyQualified=true/>" />
 </@hst.headContribution>
 
+<#--  Site name  -->
 <@hst.headContribution category="pageMetaData">
     <meta property="og:site_name" content="${hstRequestContext.resolvedMount.mount.channelInfo.organisationName} | ${hstRequestContext.resolvedMount.mount.channelInfo.organisationDescriptor}" />
+</@hst.headContribution>
+<#--  Open Graph meta tags: END  -->
+
+<#--  Canonical URL  -->
+<@hst.headContribution category="pageMetaData">
+    <link rel="canonical" href="${pageURL!}" />
 </@hst.headContribution>


### PR DESCRIPTION
- Included additional `invalidSearchTerms` for search results to return `400 (Bad request)` for the issue described in the ticket. We can look to remove this temporary solution later once the permanent solution of adding canonical URLs to pages works.
- Included canonical URLs for all pages.
- Included `noindex` `robots` meta tag for listing/collection pages to instruct crawlers not to index them.