### PR TITLE
[NWPS-1784] Publication landing page documents file icon accessibility improvement

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/catalog/publicationlandingpage-main.ftl
@@ -58,7 +58,7 @@
                 <div class="hee-publication-doc__icon__corner__triangle"></div>
             </div>
         </div>
-        <div class="hee-publication-doc__icon__title">${fileType}</div>
+        <div class="hee-publication-doc__icon__title" aria-hidden="true">${fileType}</div>
     </div>
 </#macro>
 


### PR DESCRIPTION
Added `aria-hidden="true"` to file icon title element (`<div class="hee-publication-doc__icon__title" aria-hidden="true">...</div>`) to instruct screen readers to ignore reading out the element, thanks