### PR TITLE
NWPS-1836-Media-embed-restrictions

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental-media-embed.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-dental-media-embed:
+        jcr:primaryType: hipposys:domain
+        /content-domain:
+          jcr:primaryType: hipposys:domainrule
+          /media-embed-and-descendants:
+            jcr:primaryType: hipposys:facetrule
+            hipposys:equals: true
+            hipposys:facet: jcr:path
+            hipposys:type: Reference
+            hipposys:value: /content/documents/dental/components/national/media
+        /readonly:
+          jcr:primaryType: hipposys:authrole
+          hipposys:role: readonly
+          hipposys:userrole: xm.content.user
+          hipposys:users: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental.yaml
@@ -16,6 +16,12 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/documents/dental/settings
+        /exclude-medical-media-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/dental/components/national/media
       /author:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation-media-embed.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-digital-transformation-media-embed:
+        jcr:primaryType: hipposys:domain
+        /content-domain:
+          jcr:primaryType: hipposys:domainrule
+          /media-embed-and-descendants:
+            jcr:primaryType: hipposys:facetrule
+            hipposys:equals: true
+            hipposys:facet: jcr:path
+            hipposys:type: Reference
+            hipposys:value: /content/documents/digital-transformation/components/national/media-embed
+        /readonly:
+          jcr:primaryType: hipposys:authrole
+          hipposys:role: readonly
+          hipposys:userrole: xm.content.user
+          hipposys:users: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation.yaml
@@ -16,6 +16,12 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/documents/digital-transformation/settings
+        /exclude-digital-transformation-media-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/digital-transformation/components/national/media-embed
       /author:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-feedback-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-feedback-media-embed.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-feedback-media-embed:
+        jcr:primaryType: hipposys:domain
+        /content-domain:
+          jcr:primaryType: hipposys:domainrule
+          /media-embed-and-descendants:
+            jcr:primaryType: hipposys:facetrule
+            hipposys:equals: true
+            hipposys:facet: jcr:path
+            hipposys:type: Reference
+            hipposys:value: /content/documents/feedback/components/national/media
+        /readonly:
+          jcr:primaryType: hipposys:authrole
+          hipposys:role: readonly
+          hipposys:userrole: xm.content.user
+          hipposys:users: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-feedback.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-feedback.yaml
@@ -16,6 +16,12 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/documents/feedback/settings
+        /exclude-feedback-media-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/feedback/components/national/media
       /author:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-kls-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-kls-media-embed.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-kls-media-embed:
+        jcr:primaryType: hipposys:domain
+        /content-domain:
+          jcr:primaryType: hipposys:domainrule
+          /media-embed-and-descendants:
+            jcr:primaryType: hipposys:facetrule
+            hipposys:equals: true
+            hipposys:facet: jcr:path
+            hipposys:type: Reference
+            hipposys:value: /content/documents/kls/components/national/media
+        /readonly:
+          jcr:primaryType: hipposys:authrole
+          hipposys:role: readonly
+          hipposys:userrole: xm.content.user
+          hipposys:users: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-kls.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-kls.yaml
@@ -16,6 +16,12 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/documents/kls/settings
+        /exclude-kls-media-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/kls/components/national/media
       /author:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-media-embed.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-lks-media-embed:
+        jcr:primaryType: hipposys:domain
+        /content-domain:
+          jcr:primaryType: hipposys:domainrule
+          /media-embed-and-descendants:
+            jcr:primaryType: hipposys:facetrule
+            hipposys:equals: true
+            hipposys:facet: jcr:path
+            hipposys:type: Reference
+            hipposys:value: /content/documents/lks/media-embeds
+        /readonly:
+          jcr:primaryType: hipposys:authrole
+          hipposys:role: readonly
+          hipposys:userrole: xm.content.user
+          hipposys:users: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks.yaml
@@ -16,6 +16,12 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/documents/lks/settings
+        /exclude-lks-media-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/lks/media-embeds
       /author:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-medical-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-medical-media-embed.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-medical-media-embed:
+        jcr:primaryType: hipposys:domain
+        /content-domain:
+          jcr:primaryType: hipposys:domainrule
+          /media-embed-and-descendants:
+            jcr:primaryType: hipposys:facetrule
+            hipposys:equals: true
+            hipposys:facet: jcr:path
+            hipposys:type: Reference
+            hipposys:value: /content/documents/medical/components/national/media
+        /readonly:
+          jcr:primaryType: hipposys:authrole
+          hipposys:role: readonly
+          hipposys:userrole: xm.content.user
+          hipposys:users: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-medical.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-medical.yaml
@@ -16,6 +16,12 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/documents/medical/settings
+        /exclude-medical-media-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/medical/components/national/media
       /author:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-website-testing-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-website-testing-media-embed.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-website-testing-media-embed:
+        jcr:primaryType: hipposys:domain
+        /content-domain:
+          jcr:primaryType: hipposys:domainrule
+          /media-embed-and-descendants:
+            jcr:primaryType: hipposys:facetrule
+            hipposys:equals: true
+            hipposys:facet: jcr:path
+            hipposys:type: Reference
+            hipposys:value: /content/documents/website-testing/components/national/media
+        /readonly:
+          jcr:primaryType: hipposys:authrole
+          hipposys:role: readonly
+          hipposys:userrole: xm.content.user
+          hipposys:users: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-website-testing.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-website-testing.yaml
@@ -16,6 +16,12 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/documents/website-testing/settings
+        /exclude-website-testing-media-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/website-testing/components/national/media
       /author:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-wte-alpha-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-wte-alpha-media-embed.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:domains/content-wte-alpha-media-embed:
+        jcr:primaryType: hipposys:domain
+        /content-domain:
+          jcr:primaryType: hipposys:domainrule
+          /media-embed-and-descendants:
+            jcr:primaryType: hipposys:facetrule
+            hipposys:equals: true
+            hipposys:facet: jcr:path
+            hipposys:type: Reference
+            hipposys:value: /content/documents/wte-alpha/components/national/media
+        /readonly:
+          jcr:primaryType: hipposys:authrole
+          hipposys:role: readonly
+          hipposys:userrole: xm.content.user
+          hipposys:users: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-wte-alpha.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-wte-alpha.yaml
@@ -16,6 +16,12 @@ definitions:
           hipposys:facet: jcr:path
           hipposys:type: Reference
           hipposys:value: /content/documents/wte-alpha/settings
+        /exclude-wte-alpha-media-folder-and-descendants:
+          jcr:primaryType: hipposys:facetrule
+          hipposys:equals: false
+          hipposys:facet: jcr:path
+          hipposys:type: Reference
+          hipposys:value: /content/documents/wte-alpha/components/national/media
       /author:
         jcr:primaryType: hipposys:authrole
         hipposys:groups:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-document.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-document.yaml
@@ -2,4 +2,4 @@ definitions:
   config:
     /hippo:configuration/hippo:queries/hippo:templates/new-document:
       hippostd:excludePrimaryTypes: ['hee:imagesetWithCaption', 'hee:banner', 'hee:contactCard',
-        'hee:rightHandImage']
+        'hee:rightHandImage', 'hee:mediaEmbed']


### PR DESCRIPTION
- Create domains configuration to limit the media embed folders in each channel to readonly for non-admin users.
- Eliminate '[Content Block] [Main] Media Embed' option from the list of creating a ' Add new document'