### PR TITLE
NWPS-1848-Production-log-issue-Failed-to-transform-element

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental-media-embed.yaml
@@ -12,6 +12,15 @@ definitions:
             hipposys:value: /content/documents/dental/components/national/media
         /readonly:
           jcr:primaryType: hipposys:authrole
+          hipposys:groups:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            type: string
+            value: [ dental-author, dental-editor ]
           hipposys:role: readonly
-          hipposys:userrole: xm.content.user
-          hipposys:users: [ ]
+          hipposys:users:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            operation: override
+            type: string
+            value: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-dental-media-embed.yaml
@@ -16,7 +16,7 @@ definitions:
             .meta:category: system
             .meta:add-new-system-values: true
             type: string
-            value: [ dental-author, dental-editor ]
+            value: [ dental-author, dental-editor, dental-viewer ]
           hipposys:role: readonly
           hipposys:users:
             .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation-media-embed.yaml
@@ -12,6 +12,15 @@ definitions:
             hipposys:value: /content/documents/digital-transformation/components/national/media-embed
         /readonly:
           jcr:primaryType: hipposys:authrole
+          hipposys:groups:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            type: string
+            value: [ digital-transformation-author, digital-transformation-editor ]
           hipposys:role: readonly
-          hipposys:userrole: xm.content.user
-          hipposys:users: [ ]
+          hipposys:users:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            operation: override
+            type: string
+            value: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-digital-transformation-media-embed.yaml
@@ -16,7 +16,7 @@ definitions:
             .meta:category: system
             .meta:add-new-system-values: true
             type: string
-            value: [ digital-transformation-author, digital-transformation-editor ]
+            value: [ digital-transformation-author, digital-transformation-editor, digital-transformation-viewer ]
           hipposys:role: readonly
           hipposys:users:
             .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-feedback-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-feedback-media-embed.yaml
@@ -16,7 +16,7 @@ definitions:
             .meta:category: system
             .meta:add-new-system-values: true
             type: string
-            value: [ feedback-author, feedback-editor ]
+            value: [ feedback-author, feedback-editor, feedback-viewer ]
           hipposys:role: readonly
           hipposys:users:
             .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-feedback-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-feedback-media-embed.yaml
@@ -12,6 +12,15 @@ definitions:
             hipposys:value: /content/documents/feedback/components/national/media
         /readonly:
           jcr:primaryType: hipposys:authrole
+          hipposys:groups:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            type: string
+            value: [ feedback-author, feedback-editor ]
           hipposys:role: readonly
-          hipposys:userrole: xm.content.user
-          hipposys:users: [ ]
+          hipposys:users:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            operation: override
+            type: string
+            value: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-kls-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-kls-media-embed.yaml
@@ -16,7 +16,7 @@ definitions:
             .meta:category: system
             .meta:add-new-system-values: true
             type: string
-            value: [ kls-author, kls-editor ]
+            value: [ kls-author, kls-editor, kls-viewer ]
           hipposys:role: readonly
           hipposys:users:
             .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-kls-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-kls-media-embed.yaml
@@ -12,6 +12,15 @@ definitions:
             hipposys:value: /content/documents/kls/components/national/media
         /readonly:
           jcr:primaryType: hipposys:authrole
+          hipposys:groups:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            type: string
+            value: [ kls-author, kls-editor ]
           hipposys:role: readonly
-          hipposys:userrole: xm.content.user
-          hipposys:users: [ ]
+          hipposys:users:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            operation: override
+            type: string
+            value: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-media-embed.yaml
@@ -12,6 +12,15 @@ definitions:
             hipposys:value: /content/documents/lks/media-embeds
         /readonly:
           jcr:primaryType: hipposys:authrole
+          hipposys:groups:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            type: string
+            value: [ lks-author, lks-editor ]
           hipposys:role: readonly
-          hipposys:userrole: xm.content.user
-          hipposys:users: [ ]
+          hipposys:users:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            operation: override
+            type: string
+            value: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-lks-media-embed.yaml
@@ -16,7 +16,7 @@ definitions:
             .meta:category: system
             .meta:add-new-system-values: true
             type: string
-            value: [ lks-author, lks-editor ]
+            value: [ lks-author, lks-editor, lks-viewer ]
           hipposys:role: readonly
           hipposys:users:
             .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-medical-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-medical-media-embed.yaml
@@ -12,6 +12,15 @@ definitions:
             hipposys:value: /content/documents/medical/components/national/media
         /readonly:
           jcr:primaryType: hipposys:authrole
+          hipposys:groups:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            type: string
+            value: [ medical-author, medical-editor ]
           hipposys:role: readonly
-          hipposys:userrole: xm.content.user
-          hipposys:users: [ ]
+          hipposys:users:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            operation: override
+            type: string
+            value: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-medical-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-medical-media-embed.yaml
@@ -16,7 +16,7 @@ definitions:
             .meta:category: system
             .meta:add-new-system-values: true
             type: string
-            value: [ medical-author, medical-editor ]
+            value: [ medical-author, medical-editor, medical-viewer ]
           hipposys:role: readonly
           hipposys:users:
             .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-website-testing-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-website-testing-media-embed.yaml
@@ -12,6 +12,15 @@ definitions:
             hipposys:value: /content/documents/website-testing/components/national/media
         /readonly:
           jcr:primaryType: hipposys:authrole
+          hipposys:groups:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            type: string
+            value: [ website-testing-author, website-testing-editor ]
           hipposys:role: readonly
-          hipposys:userrole: xm.content.user
-          hipposys:users: [ ]
+          hipposys:users:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            operation: override
+            type: string
+            value: [ ]

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-website-testing-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-website-testing-media-embed.yaml
@@ -16,7 +16,7 @@ definitions:
             .meta:category: system
             .meta:add-new-system-values: true
             type: string
-            value: [ website-testing-author, website-testing-editor ]
+            value: [ website-testing-author, website-testing-editor, website-testing-viewer ]
           hipposys:role: readonly
           hipposys:users:
             .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-wte-alpha-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-wte-alpha-media-embed.yaml
@@ -16,7 +16,7 @@ definitions:
             .meta:category: system
             .meta:add-new-system-values: true
             type: string
-            value: [ wte-alpha-author, wte-alpha-editor ]
+            value: [ wte-alpha-author, wte-alpha-editor, wte-alpha-viewer  ]
           hipposys:role: readonly
           hipposys:users:
             .meta:category: system

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-wte-alpha-media-embed.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/content-wte-alpha-media-embed.yaml
@@ -12,6 +12,15 @@ definitions:
             hipposys:value: /content/documents/wte-alpha/components/national/media
         /readonly:
           jcr:primaryType: hipposys:authrole
+          hipposys:groups:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            type: string
+            value: [ wte-alpha-author, wte-alpha-editor ]
           hipposys:role: readonly
-          hipposys:userrole: xm.content.user
-          hipposys:users: [ ]
+          hipposys:users:
+            .meta:category: system
+            .meta:add-new-system-values: true
+            operation: override
+            type: string
+            value: [ ]


### PR DESCRIPTION
Make change in the configuration, to specify the groups that have 'readonly' permissions to  media-embed folders