### PR TITLE
 NWPS-1883-accessibility-author-card-images-should-have-alt-text

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-author.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/hee/macros/person-author.ftl
@@ -24,7 +24,7 @@
                 <#assign imgBgClass=' has-bg'>
             </#if>
             <div class="hee-card__image${imgBgClass}">
-                <div class="hee-card__initials"${imgBgStyle}>
+                <div class="hee-card__initials"${imgBgStyle} role="img" aria-label="${person.image.description!}">
                     <span>${initials}</span>
                 </div>
             </div>


### PR DESCRIPTION
Modify the freemarker tamplate to add alt text and meet the accessibility requirements