### PR TITLE
NWPS-1858-BE-Training-programme-collection-page-results-are-not-sorte…

### DIFF
--- a/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
+++ b/site/components/src/main/java/uk/nhs/hee/web/components/ListingPageComponent.java
@@ -234,7 +234,7 @@ public abstract class ListingPageComponent extends EssentialsDocumentComponent {
             return;
         }
 
-        String sortOrder = DESCENDING_SORT_ORDER;
+        String sortOrder = listingPageType.getType().equals("trainingprogramme")?ATOZ_SORT_ORDER: DESCENDING_SORT_ORDER;
 
         final List<String> sortByDateQueryParamValues =
                 HstUtils.getQueryParameterValues(request, SORT_BY_QUERY_PARAM);


### PR DESCRIPTION
…d-by-A-Z-ascending-on-load

Change the listing component to make default A to Z for training programme listing pages