### PR TITLE
[WSP-223] Adding new relic properties to cicd release pipeline

### DIFF
--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -114,4 +114,4 @@ jobs:
           password: ${{ secrets.BRC_PASSWORD }}
           distId: ${{ steps.upload.outputs.distId }}
           envName: ${{ env.BRC_ENV_NAME }}
-          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties'
+          configFilesAsSystemProperties: 'hee-smtp.properties,hee-platform.properties,hee-new-relic.properties'


### PR DESCRIPTION
Hi @FranciscoRuizHEE ,
As discussed, please find the documentation for new relic from Bloomreach here. https://xmdocumentation.bloomreach.com/bloomreach-cloud/reference-documentation/monitor-environment-with-new-relic.html

I made this pull request , changes only affecting the CI/CD pipeline to production environment. This restriction is in place as we are using limited version of new relic. Properties file has already been uploaded into mission control dashboard.